### PR TITLE
Add Mining Log to Mine Page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,7 @@ dependencies = [
  "bs58",
  "bytemuck",
  "cached",
+ "chrono",
  "dioxus",
  "dioxus-logger",
  "dioxus-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ wasm-bindgen = { version = "0.2.99", optional = true }
 wasm-bindgen-futures = { version = "0.4.41", optional = true }
 wasm-logger = { version = "0.2.0", optional = true }
 web-time = { version = "1.0.0", optional = true }
+chrono = { version = "0.4", features = ["wasmbind"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/src/components/tables/mine_table.rs
+++ b/src/components/tables/mine_table.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use chrono::{DateTime, Local};
 use solana_sdk::signature::Signature;
-use std::cmp::Ord;
 use ore_api::consts::TOKEN_DECIMALS;
 use solana_extra_wasm::program::spl_token::amount_to_ui_amount_string;
 
@@ -30,7 +29,8 @@ pub fn MineTable() -> Element {
                 },
                 rows: rsx! {
                     {
-                        let mut events = miner_events.iter().collect::<Vec<_>>();
+                        let events_guard = miner_events.read();
+                        let events = events_guard.iter().collect::<Vec<_>>();
                         if events.is_empty() {
                             rsx! {
                                 tr {
@@ -42,8 +42,6 @@ pub fn MineTable() -> Element {
                                 }
                             }
                         } else {
-                            events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-                            events.dedup_by(|a, b| a.signature == b.signature);
                             rsx! {
                                 for event in events {
                                     MineTableRow {

--- a/src/components/tables/mine_table.rs
+++ b/src/components/tables/mine_table.rs
@@ -1,0 +1,180 @@
+use dioxus::prelude::*;
+use crate::{
+    components::*,         
+    hooks::{use_miner_events, MiningEvent}
+};
+use chrono::{DateTime, Local};
+use solana_sdk::signature::Signature;
+use std::cmp::Ord;
+use ore_api::consts::TOKEN_DECIMALS;
+use solana_extra_wasm::program::spl_token::amount_to_ui_amount_string;
+
+pub fn MineTable() -> Element {
+    let miner_events = use_miner_events();    
+    rsx! {
+        Col {
+            gap: 8,
+            Subheading {
+                class: "px-5 sm:px-8",
+                title: "Mining Log"
+            }
+            Table {
+                class: "mx-0 sm:mx-8",
+                header: rsx! {
+                    TableHeader {
+                        left: "Time",
+                        right_1: "Transaction",
+                        right_2: "Score",
+                        right_3: "Reward",
+                    }
+                },
+                rows: rsx! {
+                    {
+                        let mut events = miner_events.iter().collect::<Vec<_>>();
+                        if events.is_empty() {
+                            rsx! {
+                                tr {
+                                    td {
+                                        colspan: "4",
+                                        class: "flex flex-row items-center justify-start pt-16 text-elements-lowEmphasis px-5 sm:px-3",
+                                        "No activity yet"
+                                    }
+                                }
+                            }
+                        } else {
+                            events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+                            events.dedup_by(|a, b| a.signature == b.signature);
+                            rsx! {
+                                for event in events {
+                                    MineTableRow {
+                                        event: event.clone()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn MineTableRow(
+    event: MiningEvent
+) -> Element {
+    rsx! {
+        TableRow {
+            left: rsx! {
+                MineTableRowTitle {
+                    timestamp: event.timestamp
+                }
+            },
+            right_1: rsx! {
+                MineTableRowTx {
+                    signature: event.signature
+                }
+            },
+            right_2: rsx! {
+                MineTableRowScore {
+                    pool_score: event.difficulty,
+                    member_score: event.member_difficulty
+                }
+            },
+            right_3: rsx! {
+                MineTableRowYield {
+                    net_reward: event.net_reward,
+                    member_reward: event.member_reward
+                }
+            },
+        }
+    }
+}
+
+#[component]
+fn MineTableRowTitle(
+    timestamp: u64
+) -> Element {    
+    let datetime = DateTime::from_timestamp(timestamp as i64, 0)
+        .unwrap()
+        .with_timezone(&Local);    
+    let date = datetime.format("%b %d");
+    let time = datetime.format("%I:%M %p");
+    rsx! {
+        Col {
+            class: "gap-4 my-auto",
+            span {
+                class: "font-semibold my-auto",
+                "{date}"
+            }            
+            span {
+                class: "font-medium text-xs text-elements-lowEmphasis",
+                "{time}"
+            }                        
+        }
+    }
+}
+
+#[component]
+fn MineTableRowTx(
+    signature: Signature
+) -> Element {
+    let len = signature.to_string().len();
+    let first_four = &signature.to_string()[0..4];
+    let last_four = &signature.to_string()[len - 4..len];
+    rsx! {
+        Col {
+            span {
+                class: "text-right my-auto font-medium",
+                "{first_four}...{last_four}"
+            }                
+        }
+    }
+}
+
+#[component]
+fn MineTableRowScore(    
+    pool_score: u64,
+    member_score: u64
+) -> Element {    
+    rsx! {
+        Col {
+            class: "gap-4 my-auto",
+            span {
+                class: "font-semibold my-auto",
+                "{pool_score}"
+            }            
+            span {
+                class: "font-medium text-xs text-elements-lowEmphasis",
+                "{member_score}"
+            }                        
+        }
+    }
+}
+
+#[component]
+fn MineTableRowYield(
+    net_reward: u64,
+    member_reward: u64
+) -> Element {
+    rsx! {
+        Col {
+            class: "gap-4 my-auto justify-end",
+            OreValue {
+                ui_amount_string: amount_to_ui_amount_string(net_reward, TOKEN_DECIMALS),
+                with_decimal_units: true,
+                size: TokenValueSize::Small,
+                gold: true,
+                abbreviated: true,
+            }
+            OreValue {
+                ui_amount_string: amount_to_ui_amount_string(member_reward, TOKEN_DECIMALS),
+                with_decimal_units: true,
+                size: TokenValueSize::Small,
+                gold: false,
+                abbreviated: true,
+            }
+        }
+        
+    }
+}

--- a/src/components/tables/mine_table.rs
+++ b/src/components/tables/mine_table.rs
@@ -36,7 +36,7 @@ pub fn MineTable() -> Element {
                                 tr {
                                     td {
                                         colspan: "4",
-                                        class: "flex flex-row items-center justify-start pt-16 text-elements-lowEmphasis px-5 sm:px-3",
+                                        class: "flex flex-row justify-start pt-16 text-elements-lowEmphasis px-5 sm:px-3",
                                         "No activity yet"
                                     }
                                 }
@@ -64,7 +64,8 @@ fn MineTableRow(
     event: MiningEvent
 ) -> Element {
     rsx! {
-        TableRow {
+        TableRowExternalLink {
+            to: format!("https://solscan.io/tx/{}", event.signature),
             left: rsx! {
                 MineTableRowTitle {
                     timestamp: event.timestamp
@@ -102,13 +103,12 @@ fn MineTableRowTitle(
     let time = datetime.format("%I:%M %p");
     rsx! {
         Col {
-            class: "gap-4 my-auto",
             span {
-                class: "font-semibold my-auto",
+                class: "font-medium my-auto",
                 "{date}"
             }            
             span {
-                class: "font-medium text-xs text-elements-lowEmphasis",
+                class: "text-xs text-elements-lowEmphasis",
                 "{time}"
             }                        
         }
@@ -139,13 +139,12 @@ fn MineTableRowScore(
 ) -> Element {    
     rsx! {
         Col {
-            class: "gap-4 my-auto",
             span {
-                class: "font-semibold my-auto",
+                class: "font-medium my-auto",
                 "{pool_score}"
             }            
             span {
-                class: "font-medium text-xs text-elements-lowEmphasis",
+                class: "text-xs text-elements-lowEmphasis",
                 "{member_score}"
             }                        
         }
@@ -159,19 +158,20 @@ fn MineTableRowYield(
 ) -> Element {
     rsx! {
         Col {
-            class: "gap-4 my-auto justify-end",
             OreValue {
+                class: "text-right ml-auto font-medium",
                 ui_amount_string: amount_to_ui_amount_string(net_reward, TOKEN_DECIMALS),
                 with_decimal_units: true,
                 size: TokenValueSize::Small,
-                gold: true,
+                gold: false,
                 abbreviated: true,
             }
             OreValue {
+                class: "text-right ml-auto",
                 ui_amount_string: amount_to_ui_amount_string(member_reward, TOKEN_DECIMALS),
                 with_decimal_units: true,
-                size: TokenValueSize::Small,
-                gold: false,
+                size: TokenValueSize::XSmall,
+                gold: true,
                 abbreviated: true,
             }
         }

--- a/src/components/tables/mod.rs
+++ b/src/components/tables/mod.rs
@@ -1,7 +1,9 @@
 mod stake_table;
 mod table;
 mod titled_row;
+mod mine_table;
 
 pub use stake_table::*;
 pub use table::*;
 pub use titled_row::*;
+pub use mine_table::*;

--- a/src/components/tables/table.rs
+++ b/src/components/tables/table.rs
@@ -69,7 +69,8 @@ pub fn TableHeader(
 }
 
 #[component]
-pub fn TableRow(
+pub fn TableRowExternalLink(
+    to: String,
     left: Element,
     right_1: Element,
     right_2: Option<Element>,
@@ -77,7 +78,9 @@ pub fn TableRow(
     right_4: Option<Element>,
 ) -> Element {
     rsx! {
-        Row {
+        Link {
+            to: to,
+            new_tab: true,
             class: "flex flex-row w-full min-w-max px-5 sm:px-3 h-20 sm:rounded-md transition hover:bg-controls-tertiary active:bg-controls-tertiaryHover hover:cursor-pointer",
             span {
                 class: "w-screen sm:w-full sm:min-w-96 my-auto -ml-5 sm:ml-0 px-5 sm:px-0",

--- a/src/components/tables/table.rs
+++ b/src/components/tables/table.rs
@@ -69,6 +69,55 @@ pub fn TableHeader(
 }
 
 #[component]
+pub fn TableRow(
+    left: Element,
+    right_1: Element,
+    right_2: Option<Element>,
+    right_3: Option<Element>,
+    right_4: Option<Element>,
+) -> Element {
+    rsx! {
+        Row {
+            class: "flex flex-row w-full min-w-max px-5 sm:px-3 h-20 sm:rounded-md transition hover:bg-controls-tertiary active:bg-controls-tertiaryHover hover:cursor-pointer",
+            span {
+                class: "w-screen sm:w-full sm:min-w-96 my-auto -ml-5 sm:ml-0 px-5 sm:px-0",
+                Row {
+                    class: "w-full sm:min-w-96 my-auto grow-0 shrink-0 sm:grow justify-between",
+                    span {
+                        class: "w-min sm:w-56 text-nowrap",
+                        {left}
+                    }
+                    span {
+                        class: "flex text-right w-56 my-auto justify-end",
+                        {right_1}
+                    }
+                }
+            }
+            Row {
+                if let Some(right_2) = right_2 {
+                    span {
+                        class: "flex text-right w-56 my-auto justify-end",
+                        {right_2}
+                    }
+                }
+                if let Some(right_3) = right_3 {
+                    span {
+                        class: "flex text-right w-56 my-auto justify-end",
+                        {right_3}
+                    }
+                }
+                if let Some(right_4) = right_4 {
+                    span {
+                        class: "flex text-right w-56 my-auto justify-end",
+                        {right_4}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
 pub fn TableRowLink(
     to: Route,
     left: Element,

--- a/src/hooks/miner/mod.rs
+++ b/src/hooks/miner/mod.rs
@@ -5,6 +5,8 @@ mod use_miner_native;
 mod use_miner_web;
 mod use_pool;
 mod use_mining_loop;
+mod use_miner_events;
+
 
 pub use use_miner::*;
 #[cfg(not(feature = "web"))]
@@ -13,3 +15,4 @@ pub use use_miner_native::*;
 pub use use_miner_web::*;
 pub use use_pool::*;
 pub use use_mining_loop::*;
+pub use use_miner_events::*;

--- a/src/hooks/miner/use_miner_events.rs
+++ b/src/hooks/miner/use_miner_events.rs
@@ -1,22 +1,39 @@
 use dioxus::prelude::*;
 use serde::Deserialize;
 use solana_sdk::signature::Signature;
+use std::collections::VecDeque;
 
 pub fn use_miner_events_provider() {
-    use_context_provider(|| Signal::new(Vec::<MiningEvent>::new()));
+    use_context_provider(|| Signal::new(VecDeque::<MiningEvent>::new()));
 }
 
-pub fn use_miner_events() -> Signal<Vec<MiningEvent>> {
+pub fn use_miner_events() -> Signal<VecDeque<MiningEvent>> {
     use_context()
 }
 
+impl MiningEvent {
+    pub fn add_to_signal(event: MiningEvent) {
+        let mut events = use_miner_events();
+        let mut new_events = events.read().clone();
+        
+        if new_events.contains(&event) {
+            return;
+        }
+
+        new_events.push_front(event);
+        if new_events.len() > 3 {
+            new_events.pop_back();
+        }
+        *events.write() = new_events;
+    }
+}
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct MiningEvent {   
     pub signature: Signature,
     pub timestamp: u64,
     pub difficulty: u64,
     pub net_reward: u64,
-    pub net_base_reward: u64,
+pub net_base_reward: u64,
     pub net_miner_boost_reward: u64,
     pub member_difficulty: u64,
     pub member_reward: u64

--- a/src/hooks/miner/use_miner_events.rs
+++ b/src/hooks/miner/use_miner_events.rs
@@ -1,10 +1,23 @@
 use dioxus::prelude::*;
-use ore_pool_types::PoolMemberMiningEvent;
+use serde::Deserialize;
+use solana_sdk::signature::Signature;
 
 pub fn use_miner_events_provider() {
-    use_context_provider(|| Signal::new(Vec::<PoolMemberMiningEvent>::new()));
+    use_context_provider(|| Signal::new(Vec::<MiningEvent>::new()));
 }
 
-pub fn use_miner_events() -> Signal<Vec<PoolMemberMiningEvent>> {
+pub fn use_miner_events() -> Signal<Vec<MiningEvent>> {
     use_context()
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct MiningEvent {   
+    pub signature: Signature,
+    pub timestamp: u64,
+    pub difficulty: u64,
+    pub net_reward: u64,
+    pub net_base_reward: u64,
+    pub net_miner_boost_reward: u64,
+    pub member_difficulty: u64,
+    pub member_reward: u64
 }

--- a/src/hooks/miner/use_miner_events.rs
+++ b/src/hooks/miner/use_miner_events.rs
@@ -1,0 +1,10 @@
+use dioxus::prelude::*;
+use ore_pool_types::PoolMemberMiningEvent;
+
+pub fn use_miner_events_provider() {
+    use_context_provider(|| Signal::new(Vec::<PoolMemberMiningEvent>::new()));
+}
+
+pub fn use_miner_events() -> Signal<Vec<PoolMemberMiningEvent>> {
+    use_context()
+}

--- a/src/hooks/miner/use_mining_loop.rs
+++ b/src/hooks/miner/use_mining_loop.rs
@@ -128,7 +128,7 @@ fn use_solution_contribute(
                     member_record.restart();
                     match use_gateway().get_latest_event(pubkey, pool_url.clone()).await {
                         Ok(latest_event) => {
-                            miner_events.write().push(latest_event);                            
+                            miner_events.write().push(latest_event);    
                         }
                         Err(err) => {
                             log::error!("Error getting latest event: {:?}", err);

--- a/src/hooks/miner/use_mining_loop.rs
+++ b/src/hooks/miner/use_mining_loop.rs
@@ -7,7 +7,7 @@ use steel::Pubkey;
 
 use crate::{
     gateway::{pool::PoolGateway, GatewayResult}, 
-    hooks::{use_gateway, use_member_record, use_miner, use_miner_events, use_miner_is_active, use_miner_status, use_pool_url, use_wallet, GetPubkey, MinerStatus}
+    hooks::{use_gateway, use_member_record, use_miner, use_miner_is_active, use_miner_status, use_pool_url, use_wallet, GetPubkey, MinerStatus, MiningEvent}
 };
 
 pub fn use_mining_loop() {
@@ -103,7 +103,6 @@ fn use_solution_contribute(
     let pool_url = use_pool_url();
     let mut member_record = use_member_record();
     let mut miner_status = use_miner_status();
-    let mut miner_events = use_miner_events();
     let is_active = use_miner_is_active();
     use_effect(move || {
         // Check status
@@ -128,7 +127,7 @@ fn use_solution_contribute(
                     member_record.restart();
                     match use_gateway().get_latest_event(pubkey, pool_url.clone()).await {
                         Ok(latest_event) => {
-                            miner_events.write().push(latest_event);    
+                            MiningEvent::add_to_signal(latest_event);
                         }
                         Err(err) => {
                             log::error!("Error getting latest event: {:?}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use hooks::{use_miner_status_provider, use_mining_loop};
 use tracing::Level;
 
 use crate::{
-    hooks::{use_cache_provider, use_transaction_status_provider, use_miner_provider, use_wallet_provider},
+    hooks::{use_cache_provider, use_transaction_status_provider, use_miner_provider, use_wallet_provider, use_miner_events_provider},
     route::Route,
 };
 
@@ -29,6 +29,7 @@ fn main() {
 pub fn App() -> Element {
     use_miner_provider();
     use_miner_status_provider();
+    use_miner_events_provider();
     use_transaction_status_provider();
     use_wallet_provider();
     use_cache_provider();

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -11,20 +11,26 @@ use crate::{
 pub fn Mine() -> Element {    
     rsx! {
         Col {
-            class: "w-full h-full pb-20 sm:pb-16 max-w-2xl mx-auto px-5 sm:px-8",
-            gap: 4,
-            Heading {
-                class: "w-full",
-                title: "Mine",
-                subtitle: "Utilize spare hashpower to harvest ORE."
+            class: "w-full h-full pb-20 sm:pb-16 mx-auto px-5 sm:px-8",
+            gap: 16,
+            Col {
+                class: "w-full max-w-2xl mx-auto px-5 sm:px-8",
+                Heading {
+                    class: "w-full",
+                    title: "Mine",
+                    subtitle: "Utilize spare hashpower to harvest ORE."
+                }
+                OrbMiner {
+                    class: "relative flex w-[16rem] h-[16rem] mx-auto my-8 sm:my-16",
+                    gold: *use_miner_is_active().read()
+                }
+                MinerData {}
             }
-            OrbMiner {
-                class: "relative flex w-[16rem] h-[16rem] mx-auto my-8 sm:my-16",
-                gold: *use_miner_is_active().read()
-            }
-            MinerData {}
-            // TODO: Add activity table
-        }
+            Col {
+                class: "w-full max-w-3xl justify-center",
+                MineTable {}
+            }            
+        }                
     }
 }
 


### PR DESCRIPTION
- Introduces `MiningEvent` context to store mining events
- Add `get_latest_event` in `PoolGateway` to obtain recent mining event from Ore Pool API
- Write `MiningEvent` to Vec in `use_mining_loop.rs`
- Create `MineTable` to display activity log
- Incorporate `MineTable` in Mine page
- Add `chrono` to Cargo.toml to format timestamp output for event
- Adjust styling for Mining Log rows + Make rows link to solscan tx
- Refactor event processing logic for Mining Log