### PR TITLE
Add ORE transaction fees to all transaction builders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ serde_yaml = "0.9"
 solana-client-wasm = { version = "2.1", optional = true }
 solana-extra-wasm = { version = "2.1", optional = true }
 solana-sdk = "2.1"
+solana-program = "2.1"
 solana-client = { version = "2.1", optional = true }
 solana-account-decoder = { version = "2.1", optional = true }
 solana-transaction-status = { version = "2.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ serde_yaml = "0.9"
 solana-client-wasm = { version = "2.1", optional = true }
 solana-extra-wasm = { version = "2.1", optional = true }
 solana-sdk = "2.1"
-solana-program = "2.1"
 solana-client = { version = "2.1", optional = true }
 solana-account-decoder = { version = "2.1", optional = true }
 solana-transaction-status = { version = "2.1", optional = true }

--- a/src/components/buttons/claim_button.rs
+++ b/src/components/buttons/claim_button.rs
@@ -1,11 +1,13 @@
+use crate::{components::submit_transaction, gateway::GatewayResult};
 use dioxus::prelude::*;
 use ore_types::request::TransactionType;
 use solana_sdk::transaction::VersionedTransaction;
 
-use crate::{components::submit_transaction, gateway::GatewayResult};
-
 #[component]
-pub fn ClaimButton(transaction: Resource<GatewayResult<VersionedTransaction>>) -> Element {
+pub fn ClaimButton(
+    transaction: Resource<GatewayResult<VersionedTransaction>>,
+    tx_type: TransactionType,
+) -> Element {
     let enabled = if let Some(Ok(_)) = transaction.read().as_ref() {
         true
     } else {
@@ -18,7 +20,7 @@ pub fn ClaimButton(transaction: Resource<GatewayResult<VersionedTransaction>>) -
             disabled: !enabled,
             onclick: move |_| {
                 if let Some(Ok(transaction)) = transaction.cloned() {
-                    submit_transaction(transaction, TransactionType::PoolClaim);
+                    submit_transaction(transaction, tx_type.clone());
                 }
             },
             span {

--- a/src/components/forms/idle_deposit_form.rs
+++ b/src/components/forms/idle_deposit_form.rs
@@ -48,7 +48,7 @@ pub fn IdleDepositForm(
                 err: err,
                 tx_type: TransactionType::BoostDeposit
             }
-            Fee {}
+            Fee { priority_fee: priority_fee.clone() }
         }
     }
 }

--- a/src/components/forms/idle_deposit_form.rs
+++ b/src/components/forms/idle_deposit_form.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Col, SubmitButton, TokenInputError, TokenInputForm},
+    components::{Col, Fee, SubmitButton, TokenInputError, TokenInputForm},
     config::Token,
     gateway::{GatewayResult, UiTokenAmount},
     hooks::{on_transaction_done, use_idle_deposit_transaction},
@@ -16,9 +16,10 @@ pub fn IdleDepositForm(
     let mut input_amount = use_signal::<String>(|| "".to_owned());
     let token = use_signal(|| Some(Token::ore()));
     let err = use_signal::<Option<TokenInputError>>(|| None);
+    let priority_fee = use_signal(|| 0);
 
     // Build the transaction
-    let tx = use_idle_deposit_transaction(stake, balance, input_amount, err);
+    let tx = use_idle_deposit_transaction(stake, balance, input_amount, err, priority_fee);
 
     // Refresh data if successful transaction
     on_transaction_done(move |_sig| {
@@ -47,6 +48,7 @@ pub fn IdleDepositForm(
                 err: err,
                 tx_type: TransactionType::BoostDeposit
             }
+            Fee {}
         }
     }
 }

--- a/src/components/forms/idle_deposit_form.rs
+++ b/src/components/forms/idle_deposit_form.rs
@@ -42,13 +42,13 @@ pub fn IdleDepositForm(
                 toolbar_shortcuts: true,
                 err: err
             }
+            Fee { priority_fee: priority_fee.clone() }
             SubmitButton {
                 title: "Submit".to_string(),
                 transaction: tx,
                 err: err,
                 tx_type: TransactionType::BoostDeposit
             }
-            Fee { priority_fee: priority_fee.clone() }
         }
     }
 }

--- a/src/components/forms/idle_withdraw_form.rs
+++ b/src/components/forms/idle_withdraw_form.rs
@@ -1,7 +1,3 @@
-use dioxus::prelude::*;
-use ore_api::consts::TOKEN_DECIMALS;
-use ore_boost_api::state::Stake;
-use ore_types::request::TransactionType;
 use crate::{
     components::{Col, SubmitButton, TokenInputError, TokenInputForm},
     config::Token,
@@ -9,6 +5,10 @@ use crate::{
     hooks::{on_transaction_done, use_idle_withdraw_transaction},
     solana::spl_token::amount_to_ui_amount,
 };
+use dioxus::prelude::*;
+use ore_api::consts::TOKEN_DECIMALS;
+use ore_boost_api::state::Stake;
+use ore_types::request::TransactionType;
 
 #[component]
 pub fn IdleWithdrawForm(
@@ -18,7 +18,7 @@ pub fn IdleWithdrawForm(
     let mut input_amount = use_signal::<String>(|| "".to_owned());
     let token = use_signal(|| Some(Token::ore()));
     let err = use_signal::<Option<TokenInputError>>(|| None);
-
+    let mut priority_fee = use_signal::<u64>(|| 0);
     // Get the stake balance
     let stake_balance = use_resource(move || async move {
         let Some(Ok(stake)) = stake.cloned() else {
@@ -35,7 +35,8 @@ pub fn IdleWithdrawForm(
     });
 
     // Build the withdraw transaction
-    let tx = use_idle_withdraw_transaction(stake, input_amount, err);
+    let tx = use_idle_withdraw_transaction(stake, input_amount, err, priority_fee);
+    log::info!("Withdraw tx: {:?}", tx);
 
     // Refresh data if successful transaction
     on_transaction_done(move |_sig| {

--- a/src/components/forms/idle_withdraw_form.rs
+++ b/src/components/forms/idle_withdraw_form.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Col, SubmitButton, TokenInputError, TokenInputForm},
+    components::{Col, Fee, SubmitButton, TokenInputError, TokenInputForm},
     config::Token,
     gateway::{GatewayError, GatewayResult, UiTokenAmount},
     hooks::{on_transaction_done, use_idle_withdraw_transaction},
@@ -18,7 +18,7 @@ pub fn IdleWithdrawForm(
     let mut input_amount = use_signal::<String>(|| "".to_owned());
     let token = use_signal(|| Some(Token::ore()));
     let err = use_signal::<Option<TokenInputError>>(|| None);
-    let mut priority_fee = use_signal::<u64>(|| 0);
+    let priority_fee = use_signal::<u64>(|| 0);
     // Get the stake balance
     let stake_balance = use_resource(move || async move {
         let Some(Ok(stake)) = stake.cloned() else {
@@ -36,7 +36,6 @@ pub fn IdleWithdrawForm(
 
     // Build the withdraw transaction
     let tx = use_idle_withdraw_transaction(stake, input_amount, err, priority_fee);
-    log::info!("Withdraw tx: {:?}", tx);
 
     // Refresh data if successful transaction
     on_transaction_done(move |_sig| {
@@ -59,6 +58,7 @@ pub fn IdleWithdrawForm(
                 toolbar_shortcuts: true,
                 err: err
             }
+            Fee { priority_fee: priority_fee.clone() }
             SubmitButton {
                 title: "Submit".to_string(),
                 transaction: tx,

--- a/src/components/forms/pair_deposit_form.rs
+++ b/src/components/forms/pair_deposit_form.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Col, SubmitButton, TokenInputError, TokenInputForm},
+    components::{Col, Fee, SubmitButton, TokenInputError, TokenInputForm},
     config::BoostMeta,
     gateway::{GatewayResult, UiTokenAmount},
     hooks::{on_transaction_done, use_pair_deposit_transaction},
@@ -27,6 +27,7 @@ pub fn PairDepositForm(
     let mut input_stream_a = use_signal::<String>(|| "".to_owned());
     let mut input_stream_b = use_signal::<String>(|| "".to_owned());
     let mut err = use_signal::<Option<TokenInputError>>(|| None);
+    let priority_fee = use_signal::<u64>(|| 0);
 
     // Refresh data, if transaction success
     on_transaction_done(move |_sig| {
@@ -45,6 +46,7 @@ pub fn PairDepositForm(
         input_amount_a,
         input_amount_b,
         err,
+        priority_fee,
     );
 
     // Get tokens
@@ -150,6 +152,7 @@ pub fn PairDepositForm(
                     err: err
                 }
             }
+            Fee { priority_fee: priority_fee.clone() }
             SubmitButton {
                 title: "Submit".to_string(),
                 transaction: tx,

--- a/src/components/forms/pair_withdraw_form.rs
+++ b/src/components/forms/pair_withdraw_form.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Col, SubmitButton, TokenInputError, TokenInputForm},
+    components::{Col, Fee, SubmitButton, TokenInputError, TokenInputForm},
     config::BoostMeta,
     gateway::{GatewayResult, UiTokenAmount},
     hooks::{on_transaction_done, use_pair_withdraw_transaction, use_withdrawable_balances},
@@ -27,6 +27,7 @@ pub fn PairWithdrawForm(
     let mut input_stream_a = use_signal::<String>(|| "".to_owned());
     let mut input_stream_b = use_signal::<String>(|| "".to_owned());
     let err = use_signal::<Option<TokenInputError>>(|| None);
+    let priority_fee = use_signal::<u64>(|| 0);
 
     // Get tokens
     use_effect(move || {
@@ -52,6 +53,7 @@ pub fn PairWithdrawForm(
         input_amount_a,
         input_amount_b,
         err,
+        priority_fee,
     );
 
     // Refresh data, if transaction success
@@ -158,6 +160,7 @@ pub fn PairWithdrawForm(
                     err: err
                 }
             }
+            Fee { priority_fee: priority_fee.clone() }
             SubmitButton {
                 title: "Submit".to_string(),
                 transaction: tx,

--- a/src/components/forms/swap_form.rs
+++ b/src/components/forms/swap_form.rs
@@ -121,11 +121,13 @@ pub fn SwapForm(class: Option<String>) -> Element {
 
 #[component]
 fn SwapDetails(quote_response: Signal<Option<QuoteResponse>>) -> Element {
-    let priority_fee = use_resource(move || async move {
-        let gateway = use_gateway();
-        let priority_fee = gateway.get_recent_priority_fee_estimate(true).await;
-    });
-    log::info!("priority_fee: {:?}", priority_fee.value());
+    // let priority_fee = use_resource(move || async move {
+    //     let gateway = use_gateway();
+    //     // let priority_fee = gateway.get_recent_priority_fee_estimate(true).await;
+    //     // priority_fee
+    // });
+    // log::info!("priority_fee: {:?}", priority_fee.cloned());
+    // microlamports * price * 10^9
 
     let (price_impact_value, slippage, transaction_fee) = {
         let quote_response = &*quote_response.read();

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -1,0 +1,74 @@
+use crate::components::*;
+use dioxus::prelude::*;
+
+#[component]
+pub fn Fee(// base fee, priority fee, ore fee
+) -> Element {
+    let mut is_open = use_signal(|| false);
+    let base_fee = 0.00001; // Example values - replace with actual fee calculations
+    let priority_fee = 0.00002;
+    let ore_fee = 0.00002;
+    let total_fee = base_fee + priority_fee + ore_fee;
+
+    let max_height = if *is_open.read() {
+        "max-h-32"
+    } else {
+        "max-h-0"
+    };
+    let opacity = if *is_open.read() {
+        "opacity-100"
+    } else {
+        "opacity-0"
+    };
+
+    rsx! {
+        button {
+            class: "w-full flex flex-col transition-all duration-300 ease-in-out hover:cursor-pointer".to_string(),
+            onclick: move |_| is_open.set(!is_open.cloned()),
+            Row {
+                class: "w-full justify-between items-center",
+                Row {
+                    class: "text-elements-lowEmphasis gap-2 items-center",
+                    span {
+                        class: "font-medium",
+                        "Total Fee"
+                    }
+                    InfoIcon {
+                        class: "h-4 w-4 shrink-0",
+                    }
+                }
+                Row {
+                    class: "items-center gap-2",
+                    span {
+                        class: "text-elements-lowEmphasis font-medium",
+                        { format!("{:.5} SOL", total_fee) }
+                    }
+                }
+            }
+            Col {
+                gap: 3,
+                Col {
+                    class: "overflow-hidden transition-all duration-300 ease-in-out {max_height}",
+                    Col {
+                        class: "pt-4 gap-2 transition-opacity duration-300 {opacity}",
+                        Row {
+                            class: "w-full justify-between",
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "App Fee" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{base_fee:.5} SOL" }
+                        }
+                        Row {
+                            class: "w-full justify-between",
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana base Fee" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{priority_fee:.5} SOL" }
+                        }
+                        Row {
+                            class: "w-full justify-between",
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana priority Fee" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{ore_fee:.5} SOL" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -3,12 +3,18 @@ use crate::hooks::{APP_FEE, SOLANA_BASE_FEE};
 use dioxus::prelude::*;
 use solana_sdk::native_token::lamports_to_sol;
 
+fn format_fee(amount: f64) -> String {
+    // Remove trailing zeros after decimal point
+    let s = format!("{:.9}", amount);
+    s.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
 #[component]
 pub fn Fee(priority_fee: Signal<u64>) -> Element {
     let mut is_open = use_signal(|| false);
     let base_fee = lamports_to_sol(SOLANA_BASE_FEE);
     let app_fee = lamports_to_sol(APP_FEE);
-    let priority_fee = lamports_to_sol(priority_fee.cloned() / 1_000_000);
+    let priority_fee = lamports_to_sol(priority_fee.cloned());
 
     let total_fee = base_fee + priority_fee + app_fee;
 
@@ -41,16 +47,9 @@ pub fn Fee(priority_fee: Signal<u64>) -> Element {
                 }
                 Row {
                     class: "items-center gap-2",
-                    // TokenValueSmall {
-                    //     class: "ml-auto",
-                    //     amount: format!("{:.1$}", total_fee, 9),
-                    //     ticker: "SOL".to_string(),
-                    //     with_decimal_units: true,
-
-                    // }
                     span {
                         class: "text-elements-lowEmphasis font-medium",
-                        { format!("{:.5} SOL", total_fee) }
+                        { format!("{} SOL", format_fee(total_fee)) }
                     }
                 }
             }
@@ -63,38 +62,17 @@ pub fn Fee(priority_fee: Signal<u64>) -> Element {
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "App Fee" }
-                            // TokenValueSmall {
-                            //     class: "ml-auto",
-                            //     amount: format!("{:.1$}", app_fee, 9),
-                            //     ticker: "SOL".to_string(),
-                            //     with_decimal_units: true,
-                            //     size: Some(TokenValueSize::XSmall),
-                            // }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{app_fee:.5} SOL" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{format_fee(app_fee)}" }
                         }
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana base Fee" }
-                            // TokenValueSmall {
-                            //     class: "ml-auto",
-                            //     amount: format!("{:.1$}", base_fee, 9),
-                            //     ticker: "SOL".to_string(),
-                            //     with_decimal_units: true,
-                            //     size: Some(TokenValueSize::XSmall),
-                            // }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{base_fee:.5} SOL" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{format_fee(base_fee)}" }
                         }
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana priority Fee" }
-                            // TokenValueSmall {
-                            //     class: "ml-auto",
-                            //     amount: format!("{:.1$}", priority_fee, 9),
-                            //     ticker: "SOL".to_string(),
-                            //     with_decimal_units: true,
-                            //     size: Some(TokenValueSize::XSmall),
-                            // }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{priority_fee:.5} SOL" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{format_fee(priority_fee)}" }
                         }
                     }
                 }

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -41,6 +41,13 @@ pub fn Fee(priority_fee: Signal<u64>) -> Element {
                 }
                 Row {
                     class: "items-center gap-2",
+                    // TokenValueSmall {
+                    //     class: "ml-auto",
+                    //     amount: format!("{:.1$}", total_fee, 9),
+                    //     ticker: "SOL".to_string(),
+                    //     with_decimal_units: true,
+
+                    // }
                     span {
                         class: "text-elements-lowEmphasis font-medium",
                         { format!("{:.5} SOL", total_fee) }
@@ -56,17 +63,38 @@ pub fn Fee(priority_fee: Signal<u64>) -> Element {
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "App Fee" }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{base_fee:.5} SOL" }
+                            // TokenValueSmall {
+                            //     class: "ml-auto",
+                            //     amount: format!("{:.1$}", app_fee, 9),
+                            //     ticker: "SOL".to_string(),
+                            //     with_decimal_units: true,
+                            //     size: Some(TokenValueSize::XSmall),
+                            // }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{app_fee:.5} SOL" }
                         }
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana base Fee" }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{priority_fee:.5} SOL" }
+                            // TokenValueSmall {
+                            //     class: "ml-auto",
+                            //     amount: format!("{:.1$}", base_fee, 9),
+                            //     ticker: "SOL".to_string(),
+                            //     with_decimal_units: true,
+                            //     size: Some(TokenValueSize::XSmall),
+                            // }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{base_fee:.5} SOL" }
                         }
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana priority Fee" }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{app_fee:.5} SOL" }
+                            // TokenValueSmall {
+                            //     class: "ml-auto",
+                            //     amount: format!("{:.1$}", priority_fee, 9),
+                            //     ticker: "SOL".to_string(),
+                            //     with_decimal_units: true,
+                            //     size: Some(TokenValueSize::XSmall),
+                            // }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{priority_fee:.5} SOL" }
                         }
                     }
                 }

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -1,14 +1,16 @@
 use crate::components::*;
+use crate::hooks::{APP_FEE, SOLANA_BASE_FEE};
 use dioxus::prelude::*;
+use solana_sdk::native_token::lamports_to_sol;
 
 #[component]
-pub fn Fee(// base fee, priority fee, ore fee
-) -> Element {
+pub fn Fee(priority_fee: Signal<u64>) -> Element {
     let mut is_open = use_signal(|| false);
-    let base_fee = 0.00001; // Example values - replace with actual fee calculations
-    let priority_fee = 0.00002;
-    let ore_fee = 0.00002;
-    let total_fee = base_fee + priority_fee + ore_fee;
+    let base_fee = lamports_to_sol(SOLANA_BASE_FEE);
+    let app_fee = lamports_to_sol(APP_FEE);
+    let priority_fee = lamports_to_sol(priority_fee.cloned() / 1_000_000);
+
+    let total_fee = base_fee + priority_fee + app_fee;
 
     let max_height = if *is_open.read() {
         "max-h-32"
@@ -64,7 +66,7 @@ pub fn Fee(// base fee, priority fee, ore fee
                         Row {
                             class: "w-full justify-between",
                             span { class: "font-medium text-xs text-elements-lowEmphasis", "Solana priority Fee" }
-                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{ore_fee:.5} SOL" }
+                            span { class: "font-medium text-xs text-elements-lowEmphasis", "{app_fee:.5} SOL" }
                         }
                     }
                 }

--- a/src/components/layout/mod.rs
+++ b/src/components/layout/mod.rs
@@ -1,11 +1,13 @@
 mod alert;
 mod breadcrumbs;
+mod fee;
 mod heading;
 mod layouts;
 mod navigation;
 mod toast;
 
 pub use alert::*;
+pub use fee::*;
 pub use heading::*;
 pub use layouts::*;
 pub use navigation::*;

--- a/src/components/submit_transaction/submit_transaction_web.rs
+++ b/src/components/submit_transaction/submit_transaction_web.rs
@@ -5,7 +5,7 @@ use ore_types::request::{AppId, TransactionEvent, TransactionType};
 use solana_sdk::{message::VersionedMessage, transaction::VersionedTransaction};
 
 use crate::{
-        components::*,
+    components::*,
     gateway::{ore::OreGateway, solana::SolanaGateway, Rpc},
     hooks::{use_gateway, use_transaction_status},
 };

--- a/src/components/submit_transaction/submit_transaction_web.rs
+++ b/src/components/submit_transaction/submit_transaction_web.rs
@@ -5,7 +5,7 @@ use ore_types::request::{AppId, TransactionEvent, TransactionType};
 use solana_sdk::{message::VersionedMessage, transaction::VersionedTransaction};
 
 use crate::{
-    components::*,
+        components::*,
     gateway::{ore::OreGateway, solana::SolanaGateway, Rpc},
     hooks::{use_gateway, use_transaction_status},
 };

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -62,21 +62,12 @@ impl<R: Rpc> Gateway<R> {
                 if let Ok(res) = self.http.post(RPC_URL.to_string()).json(&req).send().await {
                     if let Ok(res) = res.json::<Value>().await {
                         log::info!("res: {:?}", res);
+                        // Get dynamic fee estimate in microlamports
                         let dynamic_fee_estimate = res["result"]["priorityFeeEstimate"]
                             .as_f64()
                             .map(|fee| fee as u64)
                             .unwrap_or(0);
-                        log::info!(
-                            "dynamic_fee_estimate before covnersion: {}",
-                            dynamic_fee_estimate
-                        );
-                        let dynamic_fee_estimate_u64 = dynamic_fee_estimate * 10_u64.pow(9);
-                        // let dynamic_fee_estimate_u64 =
-                        //     (dynamic_fee_estimate * 10_f64.powf(9.0)) as u64;
-                        log::info!(
-                            "dynamic_fee_estimate after conversion: {}",
-                            dynamic_fee_estimate_u64
-                        );
+                        log::info!("dynamic_fee_estimate: {:?}", dynamic_fee_estimate);
                         return Ok(dynamic_fee_estimate);
                     } else {
                         return Err(GatewayError::Unknown);

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,6 +7,8 @@ pub mod solana;
 pub mod spl;
 mod utils;
 
+use base64::Engine;
+use bs58::{decode, encode};
 pub use error::*;
 use serde_json::{json, Value};
 #[cfg(not(feature = "web"))]
@@ -20,8 +22,6 @@ pub use utils::*;
 
 pub const RPC_URL: &str = "https://rpc.ironforge.network/mainnet?apiKey=01J4NJDYJXSGJYE3AN6VXEB5VR";
 // pub const RPC_URL: &str = "https://rainy-alis-fast-mainnet.helius-rpc.com";
-pub const APP_FEE: u64 = 5_000;
-pub const SOLANA_BASE_FEE: u64 = 5_000;
 pub struct Gateway<R: Rpc> {
     pub rpc: R,
     pub http: reqwest::Client,
@@ -35,39 +35,61 @@ impl<R: Rpc> Gateway<R> {
         }
     }
 
-    // TODO LOOK at this for priority fee
-    pub async fn get_recent_priority_fee_estimate(&self, treasury: bool) -> u64 {
+    pub async fn get_recent_priority_fee_estimate(
+        &self,
+        treasury: bool,
+        tx: &VersionedTransaction,
+    ) -> GatewayResult<u64> {
         let mut ore_addresses: Vec<String> = vec![ore_api::id().to_string()];
         if treasury {
-            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string()); // ORE-65
+            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string());
         }
-        // let req = json!({
-        //     "jsonrpc": "2.0",
-        //     "id": "priority-fee-estimate",
-        //     "method": "getRecentPrioritizationFees",
-        //     "params": [{
-        //         "accountKeys": ore_addresses,
-        //         "options": {
-        //             "recommended": true
-        //         }
-        //     }]
-        // });
-
-        let req = json!({
-            "jsonrpc": "2.0",
-            "id": "priority-fee-estimate",
-            "method": "getRecentPrioritizationFees",
-            "params": [ore_addresses]
-        });
-        if let Ok(res) = self.http.post(RPC_URL.to_string()).json(&req).send().await {
-            if let Ok(res) = res.json::<Value>().await {
-                return res["result"]["priorityFeeEstimate"]
-                    .as_f64()
-                    .map(|fee| fee as u64)
-                    .unwrap_or(0);
+        match bincode::serialize(&tx) {
+            Ok(tx_bytes) => {
+                // let tx_base64 = base64::en::general_purpose::STANDARD.encode(tx_bytes);
+                let tx_bs58 = bs58::encode(tx_bytes).into_string();
+                let req = json!({
+                    "jsonrpc": "2.0",
+                    "id": "priority-fee-estimate",
+                    "method": "getPriorityFeeEstimate",
+                    "params": [{
+                        "transaction": tx_bs58,
+                        "options": {
+                            "recommended": true
+                        }
+                    }]
+                });
+                if let Ok(res) = self.http.post(RPC_URL.to_string()).json(&req).send().await {
+                    if let Ok(res) = res.json::<Value>().await {
+                        log::info!("res: {:?}", res);
+                        let dynamic_fee_estimate = res["result"]["priorityFeeEstimate"]
+                            .as_f64()
+                            .map(|fee| fee as u64)
+                            .unwrap_or(0);
+                        log::info!(
+                            "dynamic_fee_estimate before covnersion: {}",
+                            dynamic_fee_estimate
+                        );
+                        let dynamic_fee_estimate_u64 = dynamic_fee_estimate * 10_u64.pow(9);
+                        // let dynamic_fee_estimate_u64 =
+                        //     (dynamic_fee_estimate * 10_f64.powf(9.0)) as u64;
+                        log::info!(
+                            "dynamic_fee_estimate after conversion: {}",
+                            dynamic_fee_estimate_u64
+                        );
+                        return Ok(dynamic_fee_estimate);
+                    } else {
+                        return Err(GatewayError::Unknown);
+                    }
+                } else {
+                    return Err(GatewayError::Unknown);
+                }
+            }
+            Err(e) => {
+                log::error!("err serializing tx: {}", e);
+                Err(GatewayError::Unknown)
             }
         }
-        0
     }
 }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -20,7 +20,8 @@ pub use utils::*;
 
 pub const RPC_URL: &str = "https://rpc.ironforge.network/mainnet?apiKey=01J4NJDYJXSGJYE3AN6VXEB5VR";
 // pub const RPC_URL: &str = "https://rainy-alis-fast-mainnet.helius-rpc.com";
-
+pub const APP_FEE: u64 = 5_000;
+pub const SOLANA_BASE_FEE: u64 = 5_000;
 pub struct Gateway<R: Rpc> {
     pub rpc: R,
     pub http: reqwest::Client,
@@ -34,21 +35,29 @@ impl<R: Rpc> Gateway<R> {
         }
     }
 
-    pub async fn _get_recent_priority_fee_estimate(&self, treasury: bool) -> u64 {
+    // TODO LOOK at this for priority fee
+    pub async fn get_recent_priority_fee_estimate(&self, treasury: bool) -> u64 {
         let mut ore_addresses: Vec<String> = vec![ore_api::id().to_string()];
         if treasury {
-            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string());
+            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string()); // ORE-65
         }
+        // let req = json!({
+        //     "jsonrpc": "2.0",
+        //     "id": "priority-fee-estimate",
+        //     "method": "getRecentPrioritizationFees",
+        //     "params": [{
+        //         "accountKeys": ore_addresses,
+        //         "options": {
+        //             "recommended": true
+        //         }
+        //     }]
+        // });
+
         let req = json!({
             "jsonrpc": "2.0",
             "id": "priority-fee-estimate",
-            "method": "getPriorityFeeEstimate",
-            "params": [{
-                "accountKeys": ore_addresses,
-                "options": {
-                    "recommended": true
-                }
-            }]
+            "method": "getRecentPrioritizationFees",
+            "params": [ore_addresses]
         });
         if let Ok(res) = self.http.post(RPC_URL.to_string()).json(&req).send().await {
             if let Ok(res) = res.json::<Value>().await {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -37,13 +37,10 @@ impl<R: Rpc> Gateway<R> {
 
     pub async fn get_recent_priority_fee_estimate(
         &self,
-        treasury: bool, // remove this
         tx: &VersionedTransaction,
     ) -> GatewayResult<u64> {
-        let mut ore_addresses: Vec<String> = vec![ore_api::id().to_string()];
-        if treasury {
-            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string()); // remove this
-        }
+        // let mut ore_addresses: Vec<String> = vec![ore_api::id().to_string()];
+
         match bincode::serialize(&tx) {
             Ok(tx_bytes) => {
                 // let tx_base64 = base64::en::general_purpose::STANDARD.encode(tx_bytes);
@@ -70,9 +67,11 @@ impl<R: Rpc> Gateway<R> {
                         log::info!("dynamic_fee_estimate: {:?}", dynamic_fee_estimate);
                         return Ok(dynamic_fee_estimate);
                     } else {
+                        log::error!("Failed to parse priority fee json");
                         return Err(GatewayError::Unknown);
                     }
                 } else {
+                    log::error!("Failed to send priority fee estimate request");
                     return Err(GatewayError::Unknown);
                 }
             }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -37,12 +37,12 @@ impl<R: Rpc> Gateway<R> {
 
     pub async fn get_recent_priority_fee_estimate(
         &self,
-        treasury: bool,
+        treasury: bool, // remove this
         tx: &VersionedTransaction,
     ) -> GatewayResult<u64> {
         let mut ore_addresses: Vec<String> = vec![ore_api::id().to_string()];
         if treasury {
-            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string());
+            ore_addresses.push(ore_api::consts::TREASURY_ADDRESS.to_string()); // remove this
         }
         match bincode::serialize(&tx) {
             Ok(tx_bytes) => {

--- a/src/hooks/resources/mod.rs
+++ b/src/hooks/resources/mod.rs
@@ -18,10 +18,6 @@ pub use use_ore_price::*;
 pub use use_stake::*;
 pub use use_token_balance::*;
 
-pub const MIN_SOL_BALANCE: f64 = 0.1;
-pub const APP_FEE: u64 = 5_000;
-pub const SOLANA_BASE_FEE: u64 = 5_000;
-
 pub fn use_cache_provider() {
     use_boosts_provider();
     use_liquidity_pairs_provider();
@@ -30,5 +26,4 @@ pub fn use_cache_provider() {
     use_members_provider();
     use_boost_yield_provider();
     use_token_balance_provider();
-    // TODO ADD TOKEENS
 }

--- a/src/hooks/resources/mod.rs
+++ b/src/hooks/resources/mod.rs
@@ -19,6 +19,8 @@ pub use use_stake::*;
 pub use use_token_balance::*;
 
 pub const MIN_SOL_BALANCE: f64 = 0.2;
+pub const APP_FEE: u64 = 5_000;
+pub const SOLANA_BASE_FEE: u64 = 5_000;
 
 pub fn use_cache_provider() {
     use_boosts_provider();

--- a/src/hooks/resources/mod.rs
+++ b/src/hooks/resources/mod.rs
@@ -18,7 +18,7 @@ pub use use_ore_price::*;
 pub use use_stake::*;
 pub use use_token_balance::*;
 
-pub const MIN_SOL_BALANCE: f64 = 0.2;
+pub const MIN_SOL_BALANCE: f64 = 0.1;
 pub const APP_FEE: u64 = 5_000;
 pub const SOLANA_BASE_FEE: u64 = 5_000;
 

--- a/src/hooks/resources/use_token_balance.rs
+++ b/src/hooks/resources/use_token_balance.rs
@@ -82,6 +82,7 @@ async fn get_token_balance(pubkey: Pubkey, mint: Pubkey) -> GatewayResult<UiToke
     }
 }
 
+// TODO: Shouldn't we be using use_token_balance instead of get_token_balance?
 pub fn use_token_balances_for_liquidity_pair(
     liquidity_pair: Resource<GatewayResult<LiquidityPair>>,
 ) -> (

--- a/src/hooks/transaction_builders/mod.rs
+++ b/src/hooks/transaction_builders/mod.rs
@@ -9,7 +9,11 @@ mod use_pair_withdraw_transaction;
 mod use_pool_register_transaction;
 mod use_swap_transaction;
 
-pub const COMPUTE_UNIT_BUFFER: f64 = 0.2;
+pub const MIN_SOL_BALANCE: f64 = 0.1;
+pub const APP_FEE: u64 = 5_000;
+pub const SOLANA_BASE_FEE: u64 = 5_000;
+pub const APP_FEE_ACCOUNT: &str = "tHCCE3KWKx8i8cDjX2DQ3Z7EMJkScAVwkfxdWz8SqgP";
+pub const COMPUTE_UNIT_LIMIT: u32 = 500_000;
 
 pub use use_boost_claim_all_transaction::*;
 pub use use_boost_claim_transaction::*;

--- a/src/hooks/transaction_builders/mod.rs
+++ b/src/hooks/transaction_builders/mod.rs
@@ -9,6 +9,8 @@ mod use_pair_withdraw_transaction;
 mod use_pool_register_transaction;
 mod use_swap_transaction;
 
+pub const COMPUTE_UNIT_BUFFER: f64 = 0.2;
+
 pub use use_boost_claim_all_transaction::*;
 pub use use_boost_claim_transaction::*;
 pub use use_idle_deposit_transaction::*;

--- a/src/hooks/transaction_builders/use_boost_claim_all_transaction.rs
+++ b/src/hooks/transaction_builders/use_boost_claim_all_transaction.rs
@@ -1,17 +1,16 @@
 use dioxus::prelude::*;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
     system_instruction::transfer,
     transaction::{Transaction, VersionedTransaction},
 };
 
 use crate::{
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_all_stakes, use_gateway, use_wallet, Wallet, COMPUTE_UNIT_BUFFER},
+    hooks::{use_all_stakes, use_gateway, use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::spl_associated_token_account,
 };
-
-const ESTIMATED_BOOST_CLAIM_ALL_COMPUTE_UNITS: u32 = 25906;
 
 pub fn use_boost_claim_all_transaction() -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
@@ -45,28 +44,18 @@ pub fn use_boost_claim_all_transaction() -> Resource<GatewayResult<VersionedTran
                 }
             }
 
-            // Q: Should we be including this in all builders?
             if ixs.is_empty() {
                 return Err(GatewayError::Unknown);
             }
 
-            // Adjust compute unit limit based on buffer -> 110,000
-            let adjusted_compute_unit_limit = ESTIMATED_BOOST_CLAIM_ALL_COMPUTE_UNITS
-                + (ESTIMATED_BOOST_CLAIM_ALL_COMPUTE_UNITS as f64 * COMPUTE_UNIT_BUFFER) as u32;
-
-            log::info!(
-                "adjusted_compute_unit_limit: {}",
-                adjusted_compute_unit_limit
-            );
-
             // Set compute unit limit
             ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
-                adjusted_compute_unit_limit,
+                COMPUTE_UNIT_LIMIT,
             ));
 
             // Include ORE app fee
-            let treasury_token_address = ore_api::consts::TREASURY_TOKENS_ADDRESS;
-            ixs.push(transfer(&authority, &authority, 5000));
+            let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+            ixs.push(transfer(&authority, &app_fee_account, 5000));
 
             // Build initial transaction to estimate priority fee
             let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
@@ -75,7 +64,10 @@ pub fn use_boost_claim_all_transaction() -> Resource<GatewayResult<VersionedTran
             let gateway = use_gateway();
             let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
                 Ok(fee) => fee,
-                Err(_) => return Err(GatewayError::Unknown),
+                Err(_) => {
+                    log::error!("Failed to fetch priority fee estimate");
+                    return Err(GatewayError::Unknown);
+                }
             };
 
             // Add priority fee instruction
@@ -83,7 +75,7 @@ pub fn use_boost_claim_all_transaction() -> Resource<GatewayResult<VersionedTran
                 dynamic_priority_fee,
             ));
 
-            // Build transaction with priority fee
+            // Build final tx with priority fee
             let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
             Ok(tx)
         }

--- a/src/hooks/transaction_builders/use_boost_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_boost_claim_transaction.rs
@@ -1,12 +1,18 @@
 use dioxus::prelude::*;
 use ore_boost_api::state::{Boost, Stake};
-use solana_sdk::transaction::{Transaction, VersionedTransaction};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction,
+    system_instruction::transfer,
+    transaction::{Transaction, VersionedTransaction},
+};
 
 use crate::{
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_wallet, Wallet},
+    hooks::{use_gateway, use_wallet, Wallet, COMPUTE_UNIT_BUFFER},
     solana::spl_associated_token_account,
 };
+
+const ESTIMATED_BOOST_CLAIM_COMPUTE_UNITS: u32 = 13778;
 
 pub fn use_boost_claim_transaction(
     boost: Resource<GatewayResult<Boost>>,
@@ -34,10 +40,28 @@ pub fn use_boost_claim_transaction(
 
         // Aggregate instructions
         let mut ixs = vec![];
+
+        // Adjust compute unit limit based on buffer -> 110,000
+        let adjusted_compute_unit_limit = ESTIMATED_BOOST_CLAIM_COMPUTE_UNITS
+            + (ESTIMATED_BOOST_CLAIM_COMPUTE_UNITS as f64 * COMPUTE_UNIT_BUFFER) as u32;
+
+        log::info!(
+            "adjusted_compute_unit_limit: {}",
+            adjusted_compute_unit_limit
+        );
+
+        // Set compute unit limit
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            adjusted_compute_unit_limit,
+        ));
+
+        // Derive beneficiary
         let beneficiary = spl_associated_token_account::get_associated_token_address(
             &authority,
             &ore_api::consts::MINT_ADDRESS,
         );
+
+        // Claim rewards
         ixs.push(ore_boost_api::sdk::claim(
             authority,
             beneficiary,
@@ -45,7 +69,26 @@ pub fn use_boost_claim_transaction(
             stake.rewards,
         ));
 
-        // Build transaction
+        // Include ORE app fee
+        let treasury_token_address = ore_api::consts::TREASURY_TOKENS_ADDRESS;
+        ixs.push(transfer(&authority, &authority, 5000));
+
+        // Build initial transaction to estimate priority fee
+        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+
+        // Get priority fee estimate
+        let gateway = use_gateway();
+        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+            Ok(fee) => fee,
+            Err(_) => return Err(GatewayError::Unknown),
+        };
+
+        // Add priority fee instruction
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+            dynamic_priority_fee,
+        ));
+
+        // Build transaction with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
         Ok(tx)
     })

--- a/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
@@ -1,9 +1,10 @@
 use dioxus::prelude::*;
 use ore_api::consts::{MINT_ADDRESS, TOKEN_DECIMALS};
 use ore_boost_api::state::Stake;
-use solana_program::system_instruction::transfer;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
+    system_instruction::transfer,
     transaction::{Transaction, VersionedTransaction},
 };
 
@@ -11,11 +12,9 @@ use crate::{
     components::TokenInputError,
     config::Token,
     gateway::{GatewayError, GatewayResult, UiTokenAmount},
-    hooks::{use_gateway, use_wallet, Wallet, APP_FEE, COMPUTE_UNIT_BUFFER},
+    hooks::{use_gateway, use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::spl_token::ui_amount_to_amount,
 };
-
-const ESTIMATED_IDLE_DEPOSIT_COMPUTE_UNITS: u32 = 20693;
 
 pub fn use_idle_deposit_transaction(
     stake: Resource<GatewayResult<Stake>>,
@@ -63,18 +62,9 @@ pub fn use_idle_deposit_transaction(
         // Aggregate instructions
         let mut ixs = vec![];
 
-        // Adjust compute unit limit based on buffer -> 24,831
-        let adjusted_compute_unit_limit = ESTIMATED_IDLE_DEPOSIT_COMPUTE_UNITS
-            + (ESTIMATED_IDLE_DEPOSIT_COMPUTE_UNITS as f64 * COMPUTE_UNIT_BUFFER) as u32;
-
-        log::info!(
-            "adjusted_compute_unit_limit: {}",
-            adjusted_compute_unit_limit
-        );
-
         // Set compute unit limit
         ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
-            adjusted_compute_unit_limit,
+            COMPUTE_UNIT_LIMIT,
         ));
 
         // Open stake account, if necessary
@@ -93,32 +83,36 @@ pub fn use_idle_deposit_transaction(
         ));
 
         // Include ORE app fee
-        ixs.push(transfer(
-            &authority, &authority, // TODO CHABNGE TO REGOLITH LABS
-            APP_FEE,
-        ));
+        let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+        ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // Build initial transaction
+        // Build initial transaction to estimate priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
         // Get priority fee estimate
         let gateway = use_gateway();
         let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
             Ok(fee) => fee,
-            Err(_) => return Err(GatewayError::Unknown),
+            Err(_) => {
+                log::error!("Failed to fetch priority fee estimate");
+                return Err(GatewayError::Unknown);
+            }
         };
-
-        log::info!("dynamic_priority_fee: {}", dynamic_priority_fee);
 
         // Add priority fee instruction
         ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
             dynamic_priority_fee,
         ));
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee);
+        // Calculate priority fee in lamports
+        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        let dynamic_priority_fee_in_lamports =
+            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Build final tx
+        // Set priority fee for UI
+        priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        // Build final tx with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
         Ok(tx)

--- a/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
@@ -63,6 +63,8 @@ pub fn use_idle_deposit_transaction(
         // Aggregate instructions
         let mut ixs = vec![];
 
+        // SET COMPUTE BUDGET -> 500,000 for now
+
         // Open stake account, if necessary
         if let Some(Ok(_)) = *stake.read() {
             // Do nothing
@@ -83,7 +85,7 @@ pub fn use_idle_deposit_transaction(
         // Use the correct transfer function that returns an Instruction directly
         ixs.push(solana_program::system_instruction::transfer(
             &authority,
-            &ore_api::consts::TREASURY_ADDRESS,
+            &ore_api::consts::TREASURY_ADDRESS, // TODO CHABNGE TO REGOLITH LABS
             APP_FEE,
         ));
 

--- a/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
@@ -1,10 +1,15 @@
 use dioxus::prelude::*;
 use ore_boost_api::state::{Boost, Stake};
-use solana_sdk::transaction::{Transaction, VersionedTransaction};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
+    system_instruction::transfer,
+    transaction::{Transaction, VersionedTransaction},
+};
 
 use crate::{
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_wallet, Wallet},
+    hooks::{use_gateway, use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
 };
 
 pub fn use_lp_deposit_transaction(
@@ -26,6 +31,11 @@ pub fn use_lp_deposit_transaction(
         // Aggregate instructions
         let mut ixs = vec![];
 
+        // Set compute unit limit
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            COMPUTE_UNIT_LIMIT,
+        ));
+
         // Open the stake account, if needed
         if let Some(Ok(_stake)) = stake.read().as_ref() {
             // Do nothing
@@ -33,11 +43,39 @@ pub fn use_lp_deposit_transaction(
             ixs.push(ore_boost_api::sdk::open(authority, authority, boost.mint));
         }
 
+        // Include ORE app fee
+        let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+        ixs.push(transfer(&authority, &app_fee_account, 5000));
+
         // Deposit LP tokens
         ixs.push(ore_boost_api::sdk::deposit(authority, boost.mint, u64::MAX));
 
-        // Build transaction
+        // Build initial transaction
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-        Ok(tx)
+
+        // Get priority fee estimate
+        let gateway = use_gateway();
+        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+            Ok(fee) => fee,
+            Err(_) => {
+                log::error!("Failed to fetch priority fee estimate");
+                return Err(GatewayError::Unknown);
+            }
+        };
+
+        // Add priority fee instruction
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+            dynamic_priority_fee,
+        ));
+
+        // Calculate priority fee in lamports
+        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        let _dynamic_priority_fee_in_lamports =
+            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+
+        // Build final transaction
+        let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+
+        Ok(tx_with_priority_fee)
     })
 }

--- a/src/hooks/transaction_builders/use_miner_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_miner_claim_transaction.rs
@@ -2,20 +2,19 @@ use crate::gateway::Rpc;
 use dioxus::prelude::*;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
     system_instruction::transfer,
     transaction::{Transaction, VersionedTransaction},
 };
 
 use crate::{
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_gateway, use_wallet, Wallet, COMPUTE_UNIT_BUFFER},
+    hooks::{use_gateway, use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::{
         spl_associated_token_account::{self, get_associated_token_address},
         spl_token,
     },
 };
-
-const ESTIMATED_MINER_CLAIM_COMPUTE_UNITS: u32 = 110000;
 
 pub fn use_miner_claim_transaction(
     member_on_chain: Resource<GatewayResult<ore_pool_api::state::Member>>,
@@ -45,19 +44,10 @@ pub fn use_miner_claim_transaction(
         // Aggregate instructions
         let mut ixs = vec![];
 
-        // // Adjust compute unit limit based on buffer -> 110,000
-        // let adjusted_compute_unit_limit = ESTIMATED_MINER_CLAIM_COMPUTE_UNITS
-        //     + (ESTIMATED_MINER_CLAIM_COMPUTE_UNITS as f64 * COMPUTE_UNIT_BUFFER) as u32;
-
-        // log::info!(
-        //     "adjusted_compute_unit_limit: {}",
-        //     adjusted_compute_unit_limit
-        // );
-
-        // // Set compute unit limit
-        // ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
-        //     adjusted_compute_unit_limit,
-        // ));
+        // Set compute unit limit
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            COMPUTE_UNIT_LIMIT,
+        ));
 
         let gateway = use_gateway();
 
@@ -90,8 +80,8 @@ pub fn use_miner_claim_transaction(
         ));
 
         // Include ORE app fee
-        let treasury_token_address = ore_api::consts::TREASURY_TOKENS_ADDRESS;
-        ixs.push(transfer(&authority, &authority, 5000));
+        let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+        ixs.push(transfer(&authority, &app_fee_account, 5000));
 
         // Build initial transaction to estimate priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
@@ -99,7 +89,10 @@ pub fn use_miner_claim_transaction(
         // Get priority fee estimate
         let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
             Ok(fee) => fee,
-            Err(_) => return Err(GatewayError::Unknown),
+            Err(_) => {
+                log::error!("Failed to fetch priority fee estimate");
+                return Err(GatewayError::Unknown);
+            }
         };
 
         // Add priority fee instruction
@@ -107,8 +100,9 @@ pub fn use_miner_claim_transaction(
             dynamic_priority_fee,
         ));
 
-        // Build transaction with priority fee
+        // Build final tx with priority fee
         let tx: VersionedTransaction = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+
         Ok(tx)
     })
 }

--- a/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
@@ -133,7 +133,7 @@ pub fn use_pair_deposit_transaction(
                 &authority,
                 &wsol_ata,
                 sol_to_lamports(wsol_amount),
-            ));
+            )); // ORE-65 transfer
             ixs.push(sync_native(&spl_token::ID, &wsol_ata).unwrap());
         }
 
@@ -208,6 +208,10 @@ pub fn use_pair_deposit_transaction(
             boost_meta.lp_mint,
             u64::MAX,
         ));
+
+        // Include transsaction fee
+        let treasury_token_address = ore_api::consts::TREASURY_TOKENS_ADDRESS;
+        ixs.push(transfer(&authority, &treasury_token_address, 5000));
 
         // Build transaction
         let tx = Transaction::new_with_payer(&ixs, Some(&authority));

--- a/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
@@ -5,9 +5,11 @@ use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
     hash::Hash,
     message::{v0::Message, VersionedMessage},
+    pubkey::Pubkey,
     signature::Signature,
     system_instruction::transfer,
-    transaction::{Transaction, VersionedTransaction},
+    transaction::VersionedTransaction,
+    
 };
 
 use crate::{
@@ -17,7 +19,7 @@ use crate::{
         kamino::KaminoGateway, meteora::MeteoraGateway, GatewayError, GatewayResult, Rpc,
         UiTokenAmount,
     },
-    hooks::{use_gateway, use_wallet, Wallet, COMPUTE_UNIT_BUFFER},
+    hooks::{use_gateway, use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::{
         spl_associated_token_account::{
             get_associated_token_address, instruction::create_associated_token_account_idempotent,
@@ -31,8 +33,6 @@ use crate::{
     utils::LiquidityPair,
 };
 
-const ESTIMATED_PAIR_WITHDRAW_COMPUTE_UNITS: u32 = 323323;
-
 // Build pair deposit transaction
 pub fn use_pair_withdraw_transaction(
     boost_meta: BoostMeta,
@@ -43,6 +43,7 @@ pub fn use_pair_withdraw_transaction(
     input_amount_a: Signal<String>,
     input_amount_b: Signal<String>,
     mut err: Signal<Option<TokenInputError>>,
+    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -102,18 +103,9 @@ pub fn use_pair_withdraw_transaction(
         // Aggregate instructions
         let mut ixs = vec![];
 
-        // Adjust compute unit limit based on buffer -> 387,987
-        let adjusted_compute_unit_limit = ESTIMATED_PAIR_WITHDRAW_COMPUTE_UNITS
-            + (ESTIMATED_PAIR_WITHDRAW_COMPUTE_UNITS as f64 * COMPUTE_UNIT_BUFFER) as u32;
-
-        log::info!(
-            "adjusted_compute_unit_limit: {}",
-            adjusted_compute_unit_limit
-        );
-
         // Set compute unit limit
         ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
-            adjusted_compute_unit_limit,
+            COMPUTE_UNIT_LIMIT,
         ));
 
         // Build ore boost withdraw instruction
@@ -198,8 +190,8 @@ pub fn use_pair_withdraw_transaction(
         }
 
         // Include ORE app fee
-        let treasury_token_address = ore_api::consts::TREASURY_TOKENS_ADDRESS;
-        ixs.push(transfer(&authority, &authority, 5000));
+        let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+        ixs.push(transfer(&authority, &app_fee_account, 5000));
 
         // Build initial transaction to estimate priority fee
         let tx = VersionedTransaction {
@@ -213,7 +205,10 @@ pub fn use_pair_withdraw_transaction(
         let gateway = use_gateway();
         let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
             Ok(fee) => fee,
-            Err(_) => return Err(GatewayError::Unknown),
+            Err(_) => {
+                log::error!("Failed to fetch priority fee estimate");
+                return Err(GatewayError::Unknown);
+            }
         };
 
         // Add priority fee instruction
@@ -221,7 +216,15 @@ pub fn use_pair_withdraw_transaction(
             dynamic_priority_fee,
         ));
 
-        // Build the transaction
+        // Calculate priority fee in lamports
+        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        let dynamic_priority_fee_in_lamports =
+            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+
+        // Set priority fee for UI
+        priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        // Build final tx with priority fee
         let tx = VersionedTransaction {
             signatures: vec![Signature::default()],
             message: VersionedMessage::V0(

--- a/src/hooks/transaction_builders/use_pool_register_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_register_transaction.rs
@@ -1,12 +1,15 @@
+use crate::{
+    gateway::{GatewayError, GatewayResult},
+    hooks::{
+        use_gateway, use_pool, use_wallet, GetPubkey, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT,
+    },
+};
 use dioxus::prelude::*;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
+    system_instruction::transfer,
     transaction::{Transaction, VersionedTransaction},
-};
-
-use crate::{
-    gateway::{GatewayError, GatewayResult},
-    hooks::{use_pool, use_wallet, GetPubkey},
 };
 
 pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransaction>> {
@@ -15,10 +18,44 @@ pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransa
     use_resource(move || async move {
         if let Some(pool) = pool.cloned() {
             let pubkey = wallet.pubkey()?;
-            let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(20_000);
+            // Aggregate instructions
+            let mut ixs = vec![];
+
+            // Set compute unit limit
+            ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                COMPUTE_UNIT_LIMIT,
+            ));
+
+            // Build join instruction
             let join_ix = ore_pool_api::sdk::join(pubkey, pool.address, pubkey);
-            let tx = Transaction::new_with_payer(&[compute_budget_ix, join_ix], Some(&pubkey));
-            Ok(tx.into())
+            ixs.push(join_ix);
+
+            // Include ORE app fee
+            let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
+            ixs.push(transfer(&pubkey, &app_fee_account, APP_FEE));
+
+            // Build initial transaction to estimate priority fee
+            let tx = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
+
+            // Get priority fee estimate
+            let gateway = use_gateway();
+            let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+                Ok(fee) => fee,
+                Err(_) => {
+                    log::error!("Failed to fetch priority fee estimate");
+                    return Err(GatewayError::Unknown);
+                }
+            };
+
+            // Add priority fee instruction
+            ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+                dynamic_priority_fee,
+            ));
+
+            // Build transaction with priority fee
+            let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
+
+            Ok(tx_with_priority_fee)
         } else {
             Err(GatewayError::AccountNotFound)
         }

--- a/src/hooks/transaction_builders/use_swap_transaction.rs
+++ b/src/hooks/transaction_builders/use_swap_transaction.rs
@@ -24,7 +24,7 @@ pub fn use_swap_transaction(
     quote: Signal<Option<QuoteResponse>>,
     sell_token: Signal<Option<Token>>,
     sell_token_balance: Resource<GatewayResult<UiTokenAmount>>,
-    priority_fee: Signal<u64>,
+    _priority_fee: Signal<u64>,
     mut err: Signal<Option<TokenInputError>>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
@@ -67,6 +67,17 @@ pub fn use_swap_transaction(
                     log::error!("{:?}", err);
                     GatewayError::FailedDeserialization
                 })?;
+
+            // Get priority fee estimate
+            // let gateway = use_gateway();
+            // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&vtx).await {
+            //     Ok(fee) => fee,
+            //     Err(_) => {
+            //         log::error!("Failed to fetch priority fee estimate");
+            //         return Err(GatewayError::Unknown);
+            //     }
+            // };
+
             Ok(vtx)
         }
     })

--- a/src/hooks/transaction_builders/use_swap_transaction.rs
+++ b/src/hooks/transaction_builders/use_swap_transaction.rs
@@ -24,6 +24,7 @@ pub fn use_swap_transaction(
     quote: Signal<Option<QuoteResponse>>,
     sell_token: Signal<Option<Token>>,
     sell_token_balance: Resource<GatewayResult<UiTokenAmount>>,
+    priority_fee: Signal<u64>,
     mut err: Signal<Option<TokenInputError>>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();

--- a/src/pages/idle.rs
+++ b/src/pages/idle.rs
@@ -1,7 +1,3 @@
-use dioxus::prelude::*;
-use ore_api::consts::TOKEN_DECIMALS;
-use ore_boost_api::state::{Boost, Stake};
-
 use crate::{
     components::*,
     gateway::GatewayResult,
@@ -11,6 +7,10 @@ use crate::{
     },
     solana::spl_token::{amount_to_ui_amount, amount_to_ui_amount_string},
 };
+use dioxus::prelude::*;
+use ore_api::consts::TOKEN_DECIMALS;
+use ore_boost_api::state::{Boost, Stake};
+use ore_types::request::TransactionType;
 
 pub fn Idle() -> Element {
     let mut balance = use_ore_balance();
@@ -154,6 +154,7 @@ pub fn StakeYield(
         }
         ClaimButton {
             transaction: claim_tx.clone(),
+            tx_type: TransactionType::BoostClaim,
         }
     }
 }

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -64,6 +64,7 @@ fn MinerData() -> Element {
             MinerRewards {}
             ClaimButton {
                 transaction: claim_tx,
+                tx_type: TransactionType::PoolClaim,
             }
         }
     }

--- a/src/pages/pair.rs
+++ b/src/pages/pair.rs
@@ -35,7 +35,7 @@ pub fn Pair(lp_mint: String) -> Element {
         liquidity_pair.restart();
         lp_balance.restart();
     });
-    
+
     rsx! {
         Col {
             class: "w-full h-full pb-20 sm:pb-16",
@@ -202,12 +202,15 @@ fn UnstakedLp(
                             }
                         }
                     }
-                    SubmitButton {
-                        class: "controls-tertiary",
-                        title: "Deposit {boost_meta.ticker}",
-                        transaction: lp_deposit_tx,
-                        err: err,
-                        tx_type: TransactionType::BoostDeposit
+                    Col {
+                        class: "py-4 px-0 sm:px-3",
+                        SubmitButton {
+                            class: "controls-tertiary",
+                            title: "Deposit {boost_meta.ticker}",
+                            transaction: lp_deposit_tx,
+                            err: err,
+                            tx_type: TransactionType::BoostDeposit
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Create `Fee` component to displays fees (base, app, priority)
- Display fees on UI in withdraw + deposit forms
- Update all transactions builders (except swap) to include: CU limit, priority fee, app transfer. 
- Create `MIN_SOL_BALANCE`, `APP_FEE`, `SOLANA_BASE_FEE`, `APP_FEE_ACCOUNT`, `COMPUTE_UNIT_LIMIT` constants to be used in tx builders