### PR TITLE
Setup routing for the trade page to pre-populate buy and sell tokens

### DIFF
--- a/src/components/forms/token_picker.rs
+++ b/src/components/forms/token_picker.rs
@@ -10,10 +10,8 @@ use crate::{
 pub fn TokenPicker(
     show: Signal<bool>,
     token: Signal<Option<Token>>,
-    // buy_input_amount: Signal<String>,
-    // sell_input_amount: Signal<String>,
-    // sell_quote: UseDebounce<String>,
-    // quote_response: Signal<Option<QuoteResponse>>,
+    on_tokens_change: Option<EventHandler<(Option<Token>, Option<Token>)>>,
+    other_token: Option<Signal<Option<Token>>>,
 ) -> Element {
     let tokens = LISTED_TOKENS.values().collect::<Vec<_>>();
     let mut search = use_signal(|| String::new());
@@ -59,14 +57,21 @@ pub fn TokenPicker(
                                 onclick: {
                                     let t = t.clone();
                                     move |_| {
+                                        let old_token = token.cloned();
+
                                         // Select the new token
                                         token.set(Some(t.clone()));
                                         show.set(false);
 
-                                        // Get a new quote
-                                        // buy_input_amount.set("".to_string());
-                                        // quote_response.set(None);
-                                        // sell_quote.action(sell_input_amount.cloned());
+                                        // Update URL if on_tokens_change is provided
+                                        if let Some(on_tokens_change) = on_tokens_change {
+                                            if let Some(other_token) = other_token {
+                                                let other = other_token.cloned();
+                                                on_tokens_change.call((other, Some(t.clone())));
+                                            } else {
+                                                on_tokens_change.call((old_token, Some(t.clone())));
+                                            }
+                                        }
                                     }
                                 },
                                 img {

--- a/src/components/layout/navigation.rs
+++ b/src/components/layout/navigation.rs
@@ -157,7 +157,7 @@ fn MobileTab(title: String, route: Route) -> Element {
                             class: "h-5 w-5 mx-auto"
                         }
                     },
-                    Route::Trade {  } => rsx!{
+                    Route::Trade {} | Route::TradeWithPair { token_pair: _ } => rsx!{
                         GlobeIcon {
                             class: "h-5 w-5 mx-auto"
                         }
@@ -191,7 +191,7 @@ fn is_tab_selected(route: &Route, current_route: &Route) -> bool {
             _ => false,
         },
         Route::Trade {} => match current_route {
-            Route::Trade {} => true,
+            Route::Trade {} | Route::TradeWithPair { token_pair: _ } => true,
             _ => false,
         },
         _ => false,

--- a/src/pages/trade.rs
+++ b/src/pages/trade.rs
@@ -9,7 +9,7 @@ use crate::{
 // Update URL with token pair
 fn update_token_pair_url(navigator: &Navigator, buy: Option<Token>, sell: Option<Token>) {
     if let (Some(buy), Some(sell)) = (buy, sell) {
-        // Format URL with sell token first, then buy token
+        // Format URL with SELL-BUY
         let token_pair = format!("{}-{}", sell.ticker, buy.ticker);
         navigator.replace(Route::TradeWithPair { token_pair });
     }
@@ -26,7 +26,7 @@ pub fn Trade(token_pair: Option<String>) -> Element {
     let mut sell_token = use_signal(|| Some(Token::sol()));
 
     // Parse token pair from URL if included
-    use_memo(move || {
+    use_effect(move || {
         if let Some(pair) = &token_pair {
             // Parse the token pair in URL
             let parts: Vec<&str> = pair.split('-').collect();
@@ -49,11 +49,7 @@ pub fn Trade(token_pair: Option<String>) -> Element {
             }
         } else {
             // If we're on the /trade route without token pair, update the URL to include the default token pair
-            update_token_pair_url(
-                &navigator,
-                buy_token.peek().clone(),
-                sell_token.peek().clone(),
-            );
+            update_token_pair_url(&navigator, buy_token.cloned(), sell_token.cloned());
         }
     });
 

--- a/src/pages/trade.rs
+++ b/src/pages/trade.rs
@@ -1,10 +1,66 @@
 use dioxus::prelude::*;
 
-use crate::components::*;
+use crate::{
+    components::*,
+    config::{Token, LISTED_TOKENS_BY_TICKER},
+    route::Route,
+};
+
+// Update URL with token pair
+fn update_token_pair_url(navigator: &Navigator, buy: Option<Token>, sell: Option<Token>) {
+    if let (Some(buy), Some(sell)) = (buy, sell) {
+        // Format URL with sell token first, then buy token
+        let token_pair = format!("{}-{}", sell.ticker, buy.ticker);
+        navigator.replace(Route::TradeWithPair { token_pair });
+    }
+}
 
 // TODO Price chart component
 // TODO Activity component
-pub fn Trade() -> Element {
+#[component]
+pub fn Trade(token_pair: Option<String>) -> Element {
+    let navigator = use_navigator();
+
+    // Default tokens (SOL-ORE)
+    let mut buy_token = use_signal(|| Some(Token::ore()));
+    let mut sell_token = use_signal(|| Some(Token::sol()));
+
+    // Parse token pair from URL if included
+    use_memo(move || {
+        if let Some(pair) = &token_pair {
+            // Parse the token pair in URL
+            let parts: Vec<&str> = pair.split('-').collect();
+            if parts.len() == 2 {
+                let sell_ticker = parts[0];
+                let buy_ticker = parts[1];
+
+                // Get tokens if they exist in our list
+                let found_sell = LISTED_TOKENS_BY_TICKER.get(sell_ticker).cloned();
+                let found_buy = LISTED_TOKENS_BY_TICKER.get(buy_ticker).cloned();
+
+                // Only update if both tokens were found, otherwise use defaults
+                if found_sell.is_some() && found_buy.is_some() {
+                    sell_token.set(found_sell);
+                    buy_token.set(found_buy);
+                } else {
+                    // If either token is invalid, update URL to default pair
+                    update_token_pair_url(&navigator, Some(Token::ore()), Some(Token::sol()));
+                }
+            }
+        } else {
+            // If we're on the /trade route without token pair, update the URL to include the default token pair
+            update_token_pair_url(
+                &navigator,
+                buy_token.peek().clone(),
+                sell_token.peek().clone(),
+            );
+        }
+    });
+
+    let update_url = EventHandler::new(move |(buy, sell): (Option<Token>, Option<Token>)| {
+        update_token_pair_url(&navigator, buy, sell);
+    });
+
     rsx! {
         Col {
             class: "w-full h-full pb-20 sm:pb-16",
@@ -16,7 +72,19 @@ pub fn Trade() -> Element {
             }
             SwapForm {
                 class: "mx-auto w-full max-w-2xl px-5 sm:px-8",
+                buy_token,
+                sell_token,
+                on_tokens_change: update_url,
             }
+        }
+    }
+}
+
+#[component]
+pub fn TradeWithPair(token_pair: String) -> Element {
+    rsx! {
+        Trade {
+            token_pair: Some(token_pair)
         }
     }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -19,6 +19,8 @@ pub enum Route {
         Pair { lp_mint: String },
         #[route("/trade")]
         Trade {},
+        #[route("/trade/:token_pair")]
+        TradeWithPair { token_pair: String },
     #[end_layout]
 
     #[layout(AppModalLayout)]


### PR DESCRIPTION
- Include new route `TokenPair` to account for /trade/SELL-BUY 
- Update `trade.rs` to include route replacement/update logic
- Include event handler `update_token_pair_url` to update URL when user changes token on Trade page & `TokenPicker`