### PR TITLE
Include native SOL transfer ix in addition to SPL transfer

### DIFF
--- a/src/hooks/transaction_builders/use_transfer_transaction.rs
+++ b/src/hooks/transaction_builders/use_transfer_transaction.rs
@@ -115,14 +115,18 @@ pub fn use_transfer_transaction(
         );
 
         // Add transfer instruction
-        ixs.push(spl_transfer(
-            &spl_token::ID,
-            &from_ata,
-            &to_ata,
-            &authority,
-            &[],
-            amount_u64,
-        )?);
+        if token.mint == Token::sol().mint {
+            ixs.push(transfer(&authority, &destination, amount_u64));
+        } else {
+            ixs.push(spl_transfer(
+                &spl_token::ID,
+                &from_ata,
+                &to_ata,
+                &authority,
+                &[],
+                amount_u64,
+            )?);
+        }
 
         // Include ORE app fee
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);


### PR DESCRIPTION
- Update `use_transfer_transaction.rs` hook to include native SOL transfer tx in addition to SPL transfer