### PR TITLE
Sub Jito tips for pfee estimates

### DIFF
--- a/src/components/forms/idle_deposit_form.rs
+++ b/src/components/forms/idle_deposit_form.rs
@@ -16,10 +16,9 @@ pub fn IdleDepositForm(
     let mut input_amount = use_signal::<String>(|| "".to_owned());
     let token = use_signal(|| Some(Token::ore()));
     let err = use_signal::<Option<TokenInputError>>(|| None);
-    let priority_fee = use_signal(|| 0);
 
     // Build the transaction
-    let tx = use_idle_deposit_transaction(stake, balance, input_amount, err, priority_fee);
+    let tx = use_idle_deposit_transaction(stake, balance, input_amount, err);
 
     // Refresh data if successful transaction
     on_transaction_done(move |_sig| {
@@ -42,7 +41,7 @@ pub fn IdleDepositForm(
             }
             Col {
                 class: "w-full px-4",
-                Fee { priority_fee: priority_fee.clone() }
+                Fee {}
             }
             SubmitButton {
                 title: "Submit".to_string(),

--- a/src/components/forms/idle_withdraw_form.rs
+++ b/src/components/forms/idle_withdraw_form.rs
@@ -18,7 +18,6 @@ pub fn IdleWithdrawForm(
     let mut input_amount = use_signal::<String>(|| "".to_owned());
     let token = use_signal(|| Some(Token::ore()));
     let err = use_signal::<Option<TokenInputError>>(|| None);
-    let priority_fee = use_signal::<u64>(|| 0);
 
     // Get the stake balance
     let mut stake_balance = use_signal(|| Err(GatewayError::AccountNotFound));
@@ -39,7 +38,7 @@ pub fn IdleWithdrawForm(
     });
 
     // Build the withdraw transaction
-    let tx = use_idle_withdraw_transaction(stake, input_amount, err, priority_fee);
+    let tx = use_idle_withdraw_transaction(stake, input_amount, err);
 
     // Refresh data if successful transaction
     on_transaction_done(move |_sig| {
@@ -62,7 +61,7 @@ pub fn IdleWithdrawForm(
             }
             Col {
                 class: "w-full px-4",
-                Fee { priority_fee: priority_fee.clone() }
+                Fee {}
             }
             SubmitButton {
                 title: "Submit".to_string(),

--- a/src/components/forms/pair_deposit_form.rs
+++ b/src/components/forms/pair_deposit_form.rs
@@ -27,7 +27,6 @@ pub fn PairDepositForm(
     let mut input_stream_a = use_signal::<String>(|| "".to_owned());
     let mut input_stream_b = use_signal::<String>(|| "".to_owned());
     let mut err = use_signal::<Option<TokenInputError>>(|| None);
-    let priority_fee = use_signal::<u64>(|| 0);
 
     // Refresh data, if transaction success
     on_transaction_done(move |_sig| {
@@ -46,7 +45,6 @@ pub fn PairDepositForm(
         input_amount_a,
         input_amount_b,
         err,
-        priority_fee,
     );
 
     // Get tokens
@@ -154,7 +152,7 @@ pub fn PairDepositForm(
             }
             Col {
                 class: "w-full px-4",
-                Fee { priority_fee: priority_fee.clone() },
+                Fee {},
             }
 
             SubmitButton {

--- a/src/components/forms/pair_withdraw_form.rs
+++ b/src/components/forms/pair_withdraw_form.rs
@@ -27,7 +27,6 @@ pub fn PairWithdrawForm(
     let mut input_stream_a = use_signal::<String>(|| "".to_owned());
     let mut input_stream_b = use_signal::<String>(|| "".to_owned());
     let err = use_signal::<Option<TokenInputError>>(|| None);
-    let priority_fee = use_signal::<u64>(|| 0);
 
     // Get tokens
     use_effect(move || {
@@ -56,7 +55,6 @@ pub fn PairWithdrawForm(
         input_amount_a,
         input_amount_b,
         err,
-        priority_fee,
     );
 
     // Refresh data, if transaction success
@@ -164,7 +162,7 @@ pub fn PairWithdrawForm(
             }
             Col {
                 class: "w-full px-4",
-                Fee { priority_fee: priority_fee.clone() }
+                Fee {}
             }
             SubmitButton {
                 title: "Submit".to_string(),

--- a/src/components/forms/swap_form.rs
+++ b/src/components/forms/swap_form.rs
@@ -186,7 +186,7 @@ fn SwapDetails(
             class: "px-4",
             gap: 2,
             SwapDetailLabel { title: "Price impact", value: price_impact_value }
-            Fee { priority_fee: priority_fee.clone() }
+            Fee {}
         }
     }
 }

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -14,17 +14,12 @@ pub fn Fee() -> Element {
     let mut is_open = use_signal(|| false);
     let base_fee = lamports_to_sol(SOLANA_BASE_FEE);
     let app_fee = lamports_to_sol(APP_FEE);
-    let jito_tip_fee = lamports_to_sol(JITO_TIP_AMOUNT);
+    let jito_fee = lamports_to_sol(JITO_TIP_AMOUNT);
 
     #[cfg(feature = "web")]
     let total_fee = base_fee + app_fee;
     #[cfg(not(feature = "web"))]
-    let total_fee = base_fee + app_fee + jito_tip_fee;
-
-    #[cfg(feature = "web")]
-    let show_jito_tip = false;
-    #[cfg(not(feature = "web"))]
-    let show_jito_tip = true;
+    let total_fee = base_fee + app_fee + jito_fee;
 
     let max_height = if *is_open.read() {
         "max-h-32"
@@ -69,23 +64,17 @@ pub fn Fee() -> Element {
                         span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "App fee" }
                         span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(app_fee)}" }
                     }
+                    if cfg!(not(feature = "web")) {
+                        Row {
+                            class: "w-full justify-between",
+                            span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Jito fee" }
+                            span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(jito_fee)}" }
+                        }
+                    }
                     Row {
                         class: "w-full justify-between",
-                        span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Solana base fee" }
+                        span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Solana fee" }
                         span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(base_fee)}" }
-                    }
-                    {
-                        if show_jito_tip {
-                            rsx! {
-                                Row {
-                                    class: "w-full justify-between",
-                                    span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Jito tip fee" }
-                                    span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(jito_tip_fee)}" }
-                                }
-                            }
-                        } else {
-                            rsx! {}
-                        }
                     }
                 }
             }

--- a/src/components/layout/fee.rs
+++ b/src/components/layout/fee.rs
@@ -1,5 +1,5 @@
 use crate::components::*;
-use crate::hooks::{APP_FEE, SOLANA_BASE_FEE};
+use crate::hooks::{APP_FEE, JITO_TIP_AMOUNT, SOLANA_BASE_FEE};
 use dioxus::prelude::*;
 use solana_sdk::native_token::lamports_to_sol;
 
@@ -10,13 +10,21 @@ fn format_fee(amount: f64) -> String {
 }
 
 #[component]
-pub fn Fee(priority_fee: Signal<u64>) -> Element {
+pub fn Fee() -> Element {
     let mut is_open = use_signal(|| false);
     let base_fee = lamports_to_sol(SOLANA_BASE_FEE);
     let app_fee = lamports_to_sol(APP_FEE);
-    let priority_fee = lamports_to_sol(priority_fee.cloned());
+    let jito_tip_fee = lamports_to_sol(JITO_TIP_AMOUNT);
 
-    let total_fee = base_fee + priority_fee + app_fee;
+    #[cfg(feature = "web")]
+    let total_fee = base_fee + app_fee;
+    #[cfg(not(feature = "web"))]
+    let total_fee = base_fee + app_fee + jito_tip_fee;
+
+    #[cfg(feature = "web")]
+    let show_jito_tip = false;
+    #[cfg(not(feature = "web"))]
+    let show_jito_tip = true;
 
     let max_height = if *is_open.read() {
         "max-h-32"
@@ -66,10 +74,18 @@ pub fn Fee(priority_fee: Signal<u64>) -> Element {
                         span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Solana base fee" }
                         span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(base_fee)}" }
                     }
-                    Row {
-                        class: "w-full justify-between",
-                        span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Solana priority fee" }
-                        span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(priority_fee)}" }
+                    {
+                        if show_jito_tip {
+                            rsx! {
+                                Row {
+                                    class: "w-full justify-between",
+                                    span { class: "font-medium text-sm text-elements-lowEmphasis text-left", "Jito tip fee" }
+                                    span { class: "font-medium text-sm text-elements-lowEmphasis text-right", "{format_fee(jito_tip_fee)}" }
+                                }
+                            }
+                        } else {
+                            rsx! {}
+                        }
                     }
                 }
             }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -20,9 +20,15 @@ use solana_sdk::{
 pub use utils::*;
 pub use wss::*;
 
+#[cfg(feature = "web")]
 pub const RPC_URL: &str = "https://rpc.ironforge.network/mainnet?apiKey=01J4NJDYJXSGJYE3AN6VXEB5VR";
-pub const WSS_URL: &str =
-    "wss://atlas-mainnet.helius-rpc.com/?api-key=3e5756b4-fdcb-4a95-883c-8d6603611d1a";
+#[cfg(not(feature = "web"))]
+pub const RPC_URL: &str = "https://rpc.ironforge.network/mainnet?apiKey=01JR0QT6CKAF608VC1DKSE1KC3";
+
+#[cfg(feature = "web")]
+pub const WSS_URL: &str = "wss://rpc.ironforge.network/mainnet?apiKey=01J4NJDYJXSGJYE3AN6VXEB5VR";
+#[cfg(not(feature = "web"))]
+pub const WSS_URL: &str = "wss://rpc.ironforge.network/mainnet?apiKey=01JR0QT6CKAF608VC1DKSE1KC3";
 
 pub struct Gateway<R: Rpc> {
     pub rpc: R,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -37,7 +37,7 @@ impl<R: Rpc> Gateway<R> {
         }
     }
 
-    pub async fn get_recent_priority_fee_estimate(
+    pub async fn _get_recent_priority_fee_estimate(
         &self,
         tx: &VersionedTransaction,
     ) -> GatewayResult<u64> {

--- a/src/hooks/transaction_builders/mod.rs
+++ b/src/hooks/transaction_builders/mod.rs
@@ -31,3 +31,31 @@ pub const APP_FEE_ACCOUNT: &str = "tHCCE3KWKx8i8cDjX2DQ3Z7EMJkScAVwkfxdWz8SqgP";
 pub const SOLANA_BASE_FEE: u64 = 5_000;
 pub const COMPUTE_UNIT_LIMIT: u32 = 500_000;
 pub const MIN_SOL_BALANCE: f64 = 0.1;
+pub const JITO_TIP_AMOUNT: u64 = 2_000;
+
+#[cfg(not(feature = "web"))]
+use solana_sdk::instruction::Instruction;
+#[cfg(not(feature = "web"))]
+use solana_sdk::pubkey::Pubkey;
+
+#[cfg(not(feature = "web"))]
+pub fn tip_ix(signer: &Pubkey) -> Instruction {
+    let address = get_jito_tip_address();
+    solana_sdk::system_instruction::transfer(signer, &address, JITO_TIP_AMOUNT)
+}
+#[cfg(not(feature = "web"))]
+fn get_jito_tip_address() -> Pubkey {
+    let addresses = [
+        solana_sdk::pubkey!("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5"),
+        solana_sdk::pubkey!("HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe"),
+        solana_sdk::pubkey!("Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY"),
+        solana_sdk::pubkey!("ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49"),
+        solana_sdk::pubkey!("DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh"),
+        solana_sdk::pubkey!("ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt"),
+        solana_sdk::pubkey!("DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL"),
+        solana_sdk::pubkey!("3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT"),
+    ];
+
+    let random_index = rand::random::<usize>() % addresses.len();
+    addresses[random_index]
+}

--- a/src/hooks/transaction_builders/use_boost_claim_all_transaction.rs
+++ b/src/hooks/transaction_builders/use_boost_claim_all_transaction.rs
@@ -95,30 +95,11 @@ pub fn use_boost_claim_all_transaction() -> Resource<GatewayResult<VersionedTran
             let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
             ixs.push(transfer(&authority, &app_fee_account, 5000));
 
-            // // Build initial transaction to estimate priority fee
-            // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-            // // Get priority fee estimate
-            // let gateway = use_gateway();
-            // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            //     Ok(fee) => fee,
-            //     Err(_) => {
-            //         log::error!("Failed to fetch priority fee estimate");
-            //         return Err(GatewayError::Unknown);
-            //     }
-            // };
-
-            // // Add priority fee instruction
-            // ixs.insert(
-            //     1,
-            //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-            // );
-
             #[cfg(not(feature = "web"))]
             // Add jito tip
             ixs.push(tip_ix(&authority));
 
-            // Build final tx with priority fee
+            // Build tx
             let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
             Ok(tx)
         }

--- a/src/hooks/transaction_builders/use_boost_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_boost_claim_transaction.rs
@@ -87,30 +87,11 @@ pub fn use_boost_claim_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, 5000));
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
         Ok(tx)
     })

--- a/src/hooks/transaction_builders/use_boost_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_boost_claim_transaction.rs
@@ -11,7 +11,7 @@ use solana_sdk::{
 use crate::{
     gateway::{GatewayError, GatewayResult},
     hooks::{
-        use_claimable_yield, use_gateway, use_ore_balance, use_wallet, Wallet, APP_FEE_ACCOUNT,
+        use_claimable_yield, use_ore_balance, use_wallet, Wallet, APP_FEE_ACCOUNT,
         COMPUTE_UNIT_LIMIT,
     },
     solana::{
@@ -21,6 +21,9 @@ use crate::{
         spl_token,
     },
 };
+
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 
 pub fn use_boost_claim_transaction(
     boost: Signal<GatewayResult<Boost>>,
@@ -84,24 +87,28 @@ pub fn use_boost_claim_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, 5000));
 
-        // Build initial transaction to estimate priority fee
-        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // // Build initial transaction to estimate priority fee
+        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
@@ -88,38 +88,11 @@ pub fn use_idle_deposit_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
-        // // Set priority fee for UI
-        // priority_fee.set(dynamic_priority_fee_in_lamports);
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
         Ok(tx)

--- a/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_deposit_transaction.rs
@@ -12,16 +12,18 @@ use crate::{
     components::TokenInputError,
     config::Token,
     gateway::{GatewayError, GatewayResult, UiTokenAmount},
-    hooks::{use_gateway, use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
+    hooks::{use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::spl_token::ui_amount_to_amount,
 };
+
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 
 pub fn use_idle_deposit_transaction(
     stake: Signal<GatewayResult<Stake>>,
     ore_balance: Signal<GatewayResult<UiTokenAmount>>,
     input_amount: Signal<String>,
     mut err: Signal<Option<TokenInputError>>,
-    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -86,32 +88,36 @@ pub fn use_idle_deposit_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // Build initial transaction to estimate priority fee
-        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // // Build initial transaction to estimate priority fee
+        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee_in_lamports);
+        // // Set priority fee for UI
+        // priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/hooks/transaction_builders/use_idle_withdraw_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_withdraw_transaction.rs
@@ -79,38 +79,11 @@ pub fn use_idle_withdraw_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
-        // // Set priority fee for UI
-        // priority_fee.set(dynamic_priority_fee_in_lamports);
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
         Ok(tx)

--- a/src/hooks/transaction_builders/use_idle_withdraw_transaction.rs
+++ b/src/hooks/transaction_builders/use_idle_withdraw_transaction.rs
@@ -2,7 +2,7 @@ use crate::{
     components::TokenInputError,
     config::Token,
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_gateway, use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
+    hooks::{use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
     solana::spl_token::{amount_to_ui_amount, ui_amount_to_amount},
 };
 use dioxus::prelude::*;
@@ -15,11 +15,13 @@ use solana_sdk::{
     transaction::{Transaction, VersionedTransaction},
 };
 
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
+
 pub fn use_idle_withdraw_transaction(
     stake: Signal<GatewayResult<Stake>>,
     input_amount: Signal<String>,
     mut err: Signal<Option<TokenInputError>>,
-    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -77,32 +79,36 @@ pub fn use_idle_withdraw_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // Build initial transaction to estimate priority fee
-        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // // Build initial transaction to estimate priority fee
+        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee_in_lamports);
+        // // Set priority fee for UI
+        // priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
@@ -53,37 +53,13 @@ pub fn use_lp_deposit_transaction(
         // Deposit LP tokens
         ixs.push(ore_boost_api::sdk::deposit(authority, boost.mint, u64::MAX));
 
-        // // Build initial transaction
-        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let _dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final transaction
-        let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // Build tx
+        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        Ok(tx_with_priority_fee)
+        Ok(tx)
     })
 }

--- a/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_lp_deposit_transaction.rs
@@ -9,8 +9,11 @@ use solana_sdk::{
 
 use crate::{
     gateway::{GatewayError, GatewayResult},
-    hooks::{use_gateway, use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
+    hooks::{use_wallet, Wallet, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
 };
+
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 
 pub fn use_lp_deposit_transaction(
     boost: Signal<GatewayResult<Boost>>,
@@ -50,29 +53,33 @@ pub fn use_lp_deposit_transaction(
         // Deposit LP tokens
         ixs.push(ore_boost_api::sdk::deposit(authority, boost.mint, u64::MAX));
 
-        // Build initial transaction
-        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // // Build initial transaction
+        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let _dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let _dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final transaction
         let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
@@ -254,43 +254,11 @@ pub fn use_pair_deposit_transaction(
             }
         }
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = VersionedTransaction {
-        //     signatures: vec![Signature::default()],
-        //     message: VersionedMessage::V0(
-        //         Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
-        //     ),
-        // };
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
-        // // Set priority fee for UI
-        // priority_fee.set(dynamic_priority_fee_in_lamports);
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = VersionedTransaction {
             signatures: vec![Signature::default()],
             message: VersionedMessage::V0(

--- a/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_deposit_transaction.rs
@@ -1,17 +1,5 @@
-use dioxus::prelude::*;
-use ore_boost_api::state::Stake;
-use solana_sdk::{
-    address_lookup_table::{state::AddressLookupTable, AddressLookupTableAccount},
-    compute_budget::ComputeBudgetInstruction,
-    hash::Hash,
-    message::{v0::Message, VersionedMessage},
-    native_token::sol_to_lamports,
-    pubkey::Pubkey,
-    signature::Signature,
-    system_instruction::transfer,
-    transaction::VersionedTransaction,
-};
-
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 use crate::{
     components::TokenInputError,
     config::{BoostMeta, LpType, Token},
@@ -35,6 +23,19 @@ use crate::{
     },
     utils::LiquidityPair,
 };
+use dioxus::prelude::*;
+use ore_boost_api::state::Stake;
+use solana_sdk::{
+    address_lookup_table::{state::AddressLookupTable, AddressLookupTableAccount},
+    compute_budget::ComputeBudgetInstruction,
+    hash::Hash,
+    message::{v0::Message, VersionedMessage},
+    native_token::sol_to_lamports,
+    pubkey::Pubkey,
+    signature::Signature,
+    system_instruction::transfer,
+    transaction::VersionedTransaction,
+};
 
 // Build pair deposit transaction
 pub fn use_pair_deposit_transaction(
@@ -47,7 +48,6 @@ pub fn use_pair_deposit_transaction(
     input_amount_a: Signal<String>,
     input_amount_b: Signal<String>,
     mut err: Signal<Option<TokenInputError>>,
-    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -254,37 +254,41 @@ pub fn use_pair_deposit_transaction(
             }
         }
 
-        // Build initial transaction to estimate priority fee
-        let tx = VersionedTransaction {
-            signatures: vec![Signature::default()],
-            message: VersionedMessage::V0(
-                Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
-            ),
-        };
+        // // Build initial transaction to estimate priority fee
+        // let tx = VersionedTransaction {
+        //     signatures: vec![Signature::default()],
+        //     message: VersionedMessage::V0(
+        //         Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
+        //     ),
+        // };
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee_in_lamports);
+        // // Set priority fee for UI
+        // priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = VersionedTransaction {

--- a/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
@@ -32,6 +32,9 @@ use crate::{
     utils::LiquidityPair,
 };
 
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
+
 // Build pair deposit transaction
 pub fn use_pair_withdraw_transaction(
     boost_meta: BoostMeta,
@@ -45,7 +48,6 @@ pub fn use_pair_withdraw_transaction(
     input_amount_a: Signal<String>,
     input_amount_b: Signal<String>,
     mut err: Signal<Option<TokenInputError>>,
-    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -227,37 +229,41 @@ pub fn use_pair_withdraw_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, 5000));
 
-        // Build initial transaction to estimate priority fee
-        let tx = VersionedTransaction {
-            signatures: vec![Signature::default()],
-            message: VersionedMessage::V0(
-                Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
-            ),
-        };
+        // // Build initial transaction to estimate priority fee
+        // let tx = VersionedTransaction {
+        //     signatures: vec![Signature::default()],
+        //     message: VersionedMessage::V0(
+        //         Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
+        //     ),
+        // };
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee_in_lamports);
+        // // Set priority fee for UI
+        // priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = VersionedTransaction {

--- a/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
+++ b/src/hooks/transaction_builders/use_pair_withdraw_transaction.rs
@@ -229,43 +229,11 @@ pub fn use_pair_withdraw_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, 5000));
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = VersionedTransaction {
-        //     signatures: vec![Signature::default()],
-        //     message: VersionedMessage::V0(
-        //         Message::try_compile(&authority, &ixs, &luts, Hash::default()).unwrap(),
-        //     ),
-        // };
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
-        // // Set priority fee for UI
-        // priority_fee.set(dynamic_priority_fee_in_lamports);
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = VersionedTransaction {
             signatures: vec![Signature::default()],
             message: VersionedMessage::V0(

--- a/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
@@ -6,6 +6,8 @@ use crate::gateway::{GatewayError, Rpc};
 use crate::solana::spl_associated_token_account;
 
 #[cfg(not(feature = "web"))]
+use super::tip_ix;
+#[cfg(not(feature = "web"))]
 pub async fn build_commit_claim_instructions<R: Rpc>(
     gateway: &R,
     pool: &Pool,

--- a/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
@@ -13,7 +13,7 @@ pub async fn build_commit_claim_instructions<R: Rpc>(
     member_record_balance: u64,
 ) -> Result<Vec<solana_sdk::instruction::Instruction>, GatewayError> {
     use solana_sdk::compute_budget::ComputeBudgetInstruction;
-    let mut instructions = Vec::with_capacity(4);
+    let mut instructions = Vec::with_capacity(5);
     // compute budget
     instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(100_000));
     instructions.push(ComputeBudgetInstruction::set_compute_unit_price(20_000));
@@ -21,6 +21,8 @@ pub async fn build_commit_claim_instructions<R: Rpc>(
     let mut core_instructions =
         build_core_commit_claim_instructions(gateway, pool, member, member_record_balance).await?;
     instructions.append(&mut core_instructions);
+    // Add jito tip
+    instructions.push(tip_ix(&member.authority));
     Ok(instructions)
 }
 

--- a/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_commit_claim_transaction.rs
@@ -15,10 +15,9 @@ pub async fn build_commit_claim_instructions<R: Rpc>(
     member_record_balance: u64,
 ) -> Result<Vec<solana_sdk::instruction::Instruction>, GatewayError> {
     use solana_sdk::compute_budget::ComputeBudgetInstruction;
-    let mut instructions = Vec::with_capacity(5);
+    let mut instructions = vec![];
     // compute budget
     instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(100_000));
-    instructions.push(ComputeBudgetInstruction::set_compute_unit_price(20_000));
     // add core instructions
     let mut core_instructions =
         build_core_commit_claim_instructions(gateway, pool, member, member_record_balance).await?;

--- a/src/hooks/transaction_builders/use_pool_register_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_register_transaction.rs
@@ -15,6 +15,9 @@ use solana_sdk::{
     transaction::{Transaction, VersionedTransaction},
 };
 
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
+
 pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransaction>> {
     // wallet
     let wallet = use_wallet();
@@ -72,24 +75,9 @@ pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransa
             let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
             ixs.push(transfer(&pubkey, &app_fee_account, APP_FEE));
 
-            // // build initial transaction to estimate priority fee
-            // let tx = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
-
-            // // get priority fee estimate
-            // let gateway = use_gateway();
-            // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            //     Ok(fee) => fee,
-            //     Err(_) => {
-            //         log::error!("Failed to fetch priority fee estimate");
-            //         return Err(GatewayError::Unknown);
-            //     }
-            // };
-
-            // // add priority fee instruction
-            // ixs.insert(
-            //     1,
-            //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-            // );
+            #[cfg(not(feature = "web"))]
+            // Add jito tip
+            ixs.push(tip_ix(&pubkey));
 
             // build transaction with priority fee
             let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();

--- a/src/hooks/transaction_builders/use_pool_register_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_register_transaction.rs
@@ -72,24 +72,24 @@ pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransa
             let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
             ixs.push(transfer(&pubkey, &app_fee_account, APP_FEE));
 
-            // build initial transaction to estimate priority fee
-            let tx = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
+            // // build initial transaction to estimate priority fee
+            // let tx = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
 
-            // get priority fee estimate
-            let gateway = use_gateway();
-            let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-                Ok(fee) => fee,
-                Err(_) => {
-                    log::error!("Failed to fetch priority fee estimate");
-                    return Err(GatewayError::Unknown);
-                }
-            };
+            // // get priority fee estimate
+            // let gateway = use_gateway();
+            // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+            //     Ok(fee) => fee,
+            //     Err(_) => {
+            //         log::error!("Failed to fetch priority fee estimate");
+            //         return Err(GatewayError::Unknown);
+            //     }
+            // };
 
-            // add priority fee instruction
-            ixs.insert(
-                1,
-                ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-            );
+            // // add priority fee instruction
+            // ixs.insert(
+            //     1,
+            //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+            // );
 
             // build transaction with priority fee
             let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();

--- a/src/hooks/transaction_builders/use_swap_transaction.rs
+++ b/src/hooks/transaction_builders/use_swap_transaction.rs
@@ -16,6 +16,8 @@ use crate::{
     gateway::{GatewayError, GatewayResult, UiTokenAmount},
 };
 
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 use crate::hooks::{use_wallet, GetPubkey};
 
 const API_URL: &str = "https://quote-api.jup.ag/v6";
@@ -68,15 +70,7 @@ pub fn use_swap_transaction(
                     GatewayError::FailedDeserialization
                 })?;
 
-            // Get priority fee estimate
-            // let gateway = use_gateway();
-            // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&vtx).await {
-            //     Ok(fee) => fee,
-            //     Err(_) => {
-            //         log::error!("Failed to fetch priority fee estimate");
-            //         return Err(GatewayError::Unknown);
-            //     }
-            // };
+            // Note: We don't add Jito tip here as Jupiter's API already creates a complete transaction
 
             Ok(vtx)
         }

--- a/src/hooks/transaction_builders/use_topup_transaction.rs
+++ b/src/hooks/transaction_builders/use_topup_transaction.rs
@@ -11,15 +11,17 @@ use crate::{
     components::TokenInputError,
     config::Token,
     gateway::{GatewayError, GatewayResult, UiTokenAmount},
-    hooks::{use_gateway, use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
+    hooks::{use_wallet, Wallet, APP_FEE, APP_FEE_ACCOUNT, COMPUTE_UNIT_LIMIT},
 };
+
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
 
 pub fn use_topup_transaction(
     destination: Memo<Result<Pubkey, ParsePubkeyError>>,
     input_amount: Signal<String>,
     sol_balance: Signal<GatewayResult<UiTokenAmount>>,
     mut err: Signal<Option<TokenInputError>>,
-    mut priority_fee: Signal<u64>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();
     use_resource(move || async move {
@@ -78,32 +80,36 @@ pub fn use_topup_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // Build initial transaction to estimate priority fee
-        let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
+        // // Build initial transaction to estimate priority fee
+        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
-        // Get priority fee estimate
-        let gateway = use_gateway();
-        let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-            Ok(fee) => fee,
-            Err(_) => {
-                log::error!("Failed to fetch priority fee estimate");
-                return Err(GatewayError::Unknown);
-            }
-        };
+        // // Get priority fee estimate
+        // let gateway = use_gateway();
+        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
+        //     Ok(fee) => fee,
+        //     Err(_) => {
+        //         log::error!("Failed to fetch priority fee estimate");
+        //         return Err(GatewayError::Unknown);
+        //     }
+        // };
 
-        // Add priority fee instruction
-        ixs.insert(
-            1,
-            ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        );
+        // // Add priority fee instruction
+        // ixs.insert(
+        //     1,
+        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
+        // );
 
-        // Calculate priority fee in lamports
-        let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        let dynamic_priority_fee_in_lamports =
-            (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
+        // // Calculate priority fee in lamports
+        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
+        // let dynamic_priority_fee_in_lamports =
+        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
 
-        // Set priority fee for UI
-        priority_fee.set(dynamic_priority_fee_in_lamports);
+        // // Set priority fee for UI
+        // priority_fee.set(dynamic_priority_fee_in_lamports);
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx with priority fee
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/hooks/transaction_builders/use_topup_transaction.rs
+++ b/src/hooks/transaction_builders/use_topup_transaction.rs
@@ -80,38 +80,11 @@ pub fn use_topup_transaction(
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
 
-        // // Build initial transaction to estimate priority fee
-        // let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
-
-        // // Get priority fee estimate
-        // let gateway = use_gateway();
-        // let dynamic_priority_fee = match gateway.get_recent_priority_fee_estimate(&tx).await {
-        //     Ok(fee) => fee,
-        //     Err(_) => {
-        //         log::error!("Failed to fetch priority fee estimate");
-        //         return Err(GatewayError::Unknown);
-        //     }
-        // };
-
-        // // Add priority fee instruction
-        // ixs.insert(
-        //     1,
-        //     ComputeBudgetInstruction::set_compute_unit_price(dynamic_priority_fee),
-        // );
-
-        // // Calculate priority fee in lamports
-        // let adjusted_compute_unit_limit_u64: u64 = COMPUTE_UNIT_LIMIT.into();
-        // let dynamic_priority_fee_in_lamports =
-        //     (dynamic_priority_fee * adjusted_compute_unit_limit_u64) / 1_000_000;
-
-        // // Set priority fee for UI
-        // priority_fee.set(dynamic_priority_fee_in_lamports);
-
         #[cfg(not(feature = "web"))]
         // Add jito tip
         ixs.push(tip_ix(&authority));
 
-        // Build final tx with priority fee
+        // Build tx
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();
 
         Ok(tx)

--- a/src/hooks/transaction_builders/use_transfer_transaction.rs
+++ b/src/hooks/transaction_builders/use_transfer_transaction.rs
@@ -27,7 +27,6 @@ pub fn use_transfer_transaction(
     input_amount: Signal<String>,
     token_balance: Signal<GatewayResult<UiTokenAmount>>,
     mut err: Signal<Option<TokenInputError>>,
-    // priority_fee: Signal<u64>,
     mut address_err: Signal<Option<TransferError>>,
 ) -> Resource<GatewayResult<VersionedTransaction>> {
     let wallet = use_wallet();

--- a/src/hooks/transaction_builders/use_transfer_transaction.rs
+++ b/src/hooks/transaction_builders/use_transfer_transaction.rs
@@ -18,6 +18,9 @@ use crate::{
     },
 };
 
+#[cfg(not(feature = "web"))]
+use super::tip_ix;
+
 pub fn use_transfer_transaction(
     destination: Signal<String>,
     selected_token: Signal<Option<Token>>,
@@ -131,6 +134,10 @@ pub fn use_transfer_transaction(
         // Include ORE app fee
         let app_fee_account = Pubkey::from_str_const(APP_FEE_ACCOUNT);
         ixs.push(transfer(&authority, &app_fee_account, APP_FEE));
+
+        #[cfg(not(feature = "web"))]
+        // Add jito tip
+        ixs.push(tip_ix(&authority));
 
         // Build final tx
         let tx = Transaction::new_with_payer(&ixs, Some(&authority)).into();

--- a/src/pages/topup.rs
+++ b/src/pages/topup.rs
@@ -20,9 +20,8 @@ pub fn Topup(address: String) -> Element {
     let destination = use_memo(move || Pubkey::from_str(&address));
     let mut amount = use_signal(|| "0.2".to_string());
     let sol_balance = use_sol_balance_wss();
-    let priority_fee = use_signal(|| 0);
     let err = use_signal::<Option<TokenInputError>>(|| None);
-    let tx = use_topup_transaction(destination, amount, sol_balance, err, priority_fee);
+    let tx = use_topup_transaction(destination, amount, sol_balance, err);
     let mut status = use_signal(|| TopupStatus::Editing);
 
     on_transaction_done(move |_| {


### PR DESCRIPTION
- Include `tip_ix` + `get_jito_tip_address` functions from ore-pool to build jito tip ix
- Include `tip_ix` in transaction builders
- Add `JITO_TIP_AMOUNT`const, currently set @ 2000 lamports