### PR TITLE
Add Insufficient Sol Tx Error 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5255,7 +5255,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -7673,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "solana-client-wasm"
 version = "2.1.9"
-source = "git+https://github.com/regolith-labs/solana-playground?branch=cozmo%2Fsimulate-vtx#e6fd8dc34ff8ac2fc8017269fed7c7df60ffd835"
+source = "git+https://github.com/regolith-labs/solana-playground?branch=master#eabcd5873c1520fc3d5106235b87b74c87411bb9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "solana-extra-wasm"
 version = "2.1.9"
-source = "git+https://github.com/regolith-labs/solana-playground?branch=cozmo%2Fsimulate-vtx#e6fd8dc34ff8ac2fc8017269fed7c7df60ffd835"
+source = "git+https://github.com/regolith-labs/solana-playground?branch=master#eabcd5873c1520fc3d5106235b87b74c87411bb9"
 dependencies = [
  "Inflector",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "solana-client-wasm"
 version = "2.1.9"
-source = "git+https://github.com/regolith-labs/solana-playground?branch=master#f14fa310506f5fc2f21e768485ccbf56e34f575b"
+source = "git+https://github.com/regolith-labs/solana-playground?branch=cozmo%2Fsimulate-vtx#e6fd8dc34ff8ac2fc8017269fed7c7df60ffd835"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "solana-extra-wasm"
 version = "2.1.9"
-source = "git+https://github.com/regolith-labs/solana-playground?branch=master#f14fa310506f5fc2f21e768485ccbf56e34f575b"
+source = "git+https://github.com/regolith-labs/solana-playground?branch=cozmo%2Fsimulate-vtx#e6fd8dc34ff8ac2fc8017269fed7c7df60ffd835"
 dependencies = [
  "Inflector",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ features = [
 ]
 
 [patch.crates-io]
-solana-client-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "cozmo/simulate-vtx" }
-solana-extra-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "cozmo/simulate-vtx" }
+solana-client-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "master" }
+solana-extra-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "master" }
 kliquidity-sdk = { git = "https://github.com/regolith-labs/kliquidity-sdk", branch = "master" }
 meteora-pools-sdk = { git = "https://github.com/regolith-labs/meteora-pools-sdk", branch = "master" }
 meteora-vault-sdk = { git = "https://github.com/regolith-labs/meteora-vault-sdk", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ features = [
 ]
 
 [patch.crates-io]
-solana-client-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "master" }
-solana-extra-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "master" }
+solana-client-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "cozmo/simulate-vtx" }
+solana-extra-wasm = { version = "2.1", git = "https://github.com/regolith-labs/solana-playground", branch = "cozmo/simulate-vtx" }
 kliquidity-sdk = { git = "https://github.com/regolith-labs/kliquidity-sdk", branch = "master" }
 meteora-pools-sdk = { git = "https://github.com/regolith-labs/meteora-pools-sdk", branch = "master" }
 meteora-vault-sdk = { git = "https://github.com/regolith-labs/meteora-vault-sdk", branch = "master" }

--- a/src/components/docs/docs_staking_content.rs
+++ b/src/components/docs/docs_staking_content.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 
 use dioxus::prelude::*;
 use ore_boost_api::state::Boost;
@@ -54,7 +53,7 @@ fn StakingHowItWorks() -> Element {
     }
 }
 
-fn StakingGeneratingYield() -> Element {
+fn _StakingGeneratingYield() -> Element {
     let boost_config = use_boost_config_wss();
     let boosts = use_all_boosts();
 
@@ -155,7 +154,7 @@ fn StakingBoostBudget(
                     }
                 }
             }
-            if let Some(selected_item) = *selected_item.read() {
+            if let Some(_selected_item) = *selected_item.read() {
                 StakingBudgetBreakdown {
                     title: "Miners".to_string(),
                     description: "Miners compete to earn rewards by expending hashpower, consuming energy and computational resources. This helps tie ORE to the physical economy, and allows miners to convert electricity into liquid financial capital.".to_string(),

--- a/src/components/layout/toast.rs
+++ b/src/components/layout/toast.rs
@@ -49,10 +49,12 @@ pub fn ToastDisplay() -> Element {
                         }
                     }
                 }
+                // Remove option from transcation status & sub gatewayerror::Uknown for None into TransactionStatus::Error
                 TransactionStatus::Error(err) => {
                     // Display different error messages based on the GatewayError type
                     let error_message = match err {
-                        Some(GatewayError::InsufficientFunds) => "Insufficient SOL balance",
+                        GatewayError::InsufficientFunds => "Insufficient SOL balance",
+                        GatewayError::Unknown => "Transaction failed",
                         _ => "Transaction failed"
                     };
                     

--- a/src/components/layout/toast.rs
+++ b/src/components/layout/toast.rs
@@ -53,7 +53,7 @@ pub fn ToastDisplay() -> Element {
                 TransactionStatus::Error(err) => {
                     // Display different error messages based on the GatewayError type
                     let error_message = match err {
-                        GatewayError::InsufficientFunds => "Insufficient SOL balance",
+                        GatewayError::InsufficientSOL => "Insufficient SOL balance",
                         GatewayError::Unknown => "Transaction failed",
                         _ => "Transaction failed"
                     };

--- a/src/components/layout/toast.rs
+++ b/src/components/layout/toast.rs
@@ -13,6 +13,7 @@ pub fn ToastDisplay() -> Element {
         if let Some(transaction_status) = transaction_status.cloned() {
             match transaction_status {
                 TransactionStatus::Denied
+                | TransactionStatus::InsufficientFunds
                 | TransactionStatus::Error
                 | TransactionStatus::Timeout
                 | TransactionStatus::Done(_) => {
@@ -52,6 +53,13 @@ pub fn ToastDisplay() -> Element {
                     rsx! {
                         Col { class: "{toast_class} border-l-4 border-red-500",
                             span { class: "{title_class} my-auto", "Transaction failed" }
+                        }
+                    }
+                }
+                TransactionStatus::InsufficientFunds => {
+                    rsx! {
+                        Col { class: "{toast_class} border-l-4 border-red-500",
+                            span { class: "{title_class} my-auto", "Insufficient SOL balance" }
                         }
                     }
                 }

--- a/src/components/submit_transaction/submit_transaction_native.rs
+++ b/src/components/submit_transaction/submit_transaction_native.rs
@@ -34,9 +34,9 @@ pub fn submit_transaction(tx: VersionedTransaction, _tx_type: TransactionType) {
                 transaction_status.set(Some(TransactionStatus::Sending(0)));
                 // sign
                 if let Err(err) = sign_submit_confirm(&gateway.rpc, &signer.creator, tx).await {
-                    log::error!("{:?}", err);
+                    // log::error!("{:?}", err);
                     let err_clone = err.clone();
-                    transaction_status.set(Some(TransactionStatus::Error(Some(err_clone))));
+                    transaction_status.set(Some(TransactionStatus::Error(err_clone)));
                 }
             }
             Err(err) => {

--- a/src/components/submit_transaction/submit_transaction_native.rs
+++ b/src/components/submit_transaction/submit_transaction_native.rs
@@ -74,7 +74,7 @@ async fn sign_submit_confirm(
     if let Some(err) = simulated_tx.err {
         if let TransactionError::InstructionError(index, instruction_error) = err {
             if matches!(instruction_error, InstructionError::Custom(1)) {
-                return Err(GatewayError::InsufficientFunds);
+                return Err(GatewayError::InsufficientSOL);
             }
         }
     }

--- a/src/components/submit_transaction/submit_transaction_native.rs
+++ b/src/components/submit_transaction/submit_transaction_native.rs
@@ -35,11 +35,8 @@ pub fn submit_transaction(tx: VersionedTransaction, _tx_type: TransactionType) {
                 // sign
                 if let Err(err) = sign_submit_confirm(&gateway.rpc, &signer.creator, tx).await {
                     log::error!("{:?}", err);
-                    if let GatewayError::InsufficientFunds = err {
-                        transaction_status.set(Some(TransactionStatus::InsufficientFunds));
-                    } else {
-                        transaction_status.set(Some(TransactionStatus::Error));
-                    }
+                    let err_clone = err.clone();
+                    transaction_status.set(Some(TransactionStatus::Error(Some(err_clone))));
                 }
             }
             Err(err) => {

--- a/src/components/submit_transaction/submit_transaction_web.rs
+++ b/src/components/submit_transaction/submit_transaction_web.rs
@@ -111,7 +111,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                                     if let Some(err) = simulated_tx.err {
                                         if let TransactionError::InstructionError(index, instruction_error) = err {
                                             if matches!(instruction_error, InstructionError::Custom(1)) {
-                                                transaction_status.set(Some(TransactionStatus::InsufficientFunds));
+                                                transaction_status.set(Some(TransactionStatus::Error(Some(GatewayError::InsufficientFunds))));
                                                 return;
                                             }
                                         }
@@ -169,7 +169,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                                     }
                                     None => {
                                         log::info!("error sending tx");
-                                        transaction_status.set(Some(TransactionStatus::Error))
+                                        transaction_status.set(Some(TransactionStatus::Error(None)))
                                     }
                                 }
                             }
@@ -180,11 +180,11 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                             }
                             Err(err) => {
                                 log::error!("error signing transaction: {}", err);
-                                transaction_status.set(Some(TransactionStatus::Error))
+                                transaction_status.set(Some(TransactionStatus::Error(None)))
                             }
                             _ => {
                                 log::error!("unrecognized signing response");
-                                transaction_status.set(Some(TransactionStatus::Error))
+                                transaction_status.set(Some(TransactionStatus::Error(None)))
                             }
                         };
                     }
@@ -192,7 +192,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                     // Process eval errors
                     Err(err) => {
                         log::error!("error executing wallet signing script: {}", err);
-                        transaction_status.set(Some(TransactionStatus::Error))
+                        transaction_status.set(Some(TransactionStatus::Error(None)))
                     }
                 }
             }
@@ -200,7 +200,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
             // Process serialization errors
             Err(err) => {
                 log::error!("err serializing tx: {}", err);
-                transaction_status.set(Some(TransactionStatus::Error))
+                transaction_status.set(Some(TransactionStatus::Error(None)))
             }
         };
     });

--- a/src/components/submit_transaction/submit_transaction_web.rs
+++ b/src/components/submit_transaction/submit_transaction_web.rs
@@ -111,7 +111,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                                     if let Some(err) = simulated_tx.err {
                                         if let TransactionError::InstructionError(_index, instruction_error) = err {
                                             if matches!(instruction_error, InstructionError::Custom(1)) {
-                                                transaction_status.set(Some(TransactionStatus::Error(GatewayError::InsufficientFunds)));
+                                                transaction_status.set(Some(TransactionStatus::Error(GatewayError::InsufficientSOL)));
                                                 return;
                                             }
                                         }

--- a/src/components/submit_transaction/submit_transaction_web.rs
+++ b/src/components/submit_transaction/submit_transaction_web.rs
@@ -109,9 +109,9 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                                 // Simulate transaction to check for insufficient funds
                                 if let Ok(simulated_tx) = gateway.rpc.simulate_transaction(&tx_for_simulation).await {
                                     if let Some(err) = simulated_tx.err {
-                                        if let TransactionError::InstructionError(index, instruction_error) = err {
+                                        if let TransactionError::InstructionError(_index, instruction_error) = err {
                                             if matches!(instruction_error, InstructionError::Custom(1)) {
-                                                transaction_status.set(Some(TransactionStatus::Error(Some(GatewayError::InsufficientFunds))));
+                                                transaction_status.set(Some(TransactionStatus::Error(GatewayError::InsufficientFunds)));
                                                 return;
                                             }
                                         }
@@ -169,7 +169,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                                     }
                                     None => {
                                         log::info!("error sending tx");
-                                        transaction_status.set(Some(TransactionStatus::Error(None)))
+                                        transaction_status.set(Some(TransactionStatus::Error(GatewayError::Unknown)))
                                     }
                                 }
                             }
@@ -180,11 +180,11 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                             }
                             Err(err) => {
                                 log::error!("error signing transaction: {}", err);
-                                transaction_status.set(Some(TransactionStatus::Error(None)))
+                                transaction_status.set(Some(TransactionStatus::Error(GatewayError::Unknown)))
                             }
                             _ => {
                                 log::error!("unrecognized signing response");
-                                transaction_status.set(Some(TransactionStatus::Error(None)))
+                                transaction_status.set(Some(TransactionStatus::Error(GatewayError::Unknown)))
                             }
                         };
                     }
@@ -192,7 +192,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
                     // Process eval errors
                     Err(err) => {
                         log::error!("error executing wallet signing script: {}", err);
-                        transaction_status.set(Some(TransactionStatus::Error(None)))
+                        transaction_status.set(Some(TransactionStatus::Error(GatewayError::Unknown)))
                     }
                 }
             }
@@ -200,7 +200,7 @@ pub fn submit_transaction(mut tx: VersionedTransaction, tx_type: TransactionType
             // Process serialization errors
             Err(err) => {
                 log::error!("err serializing tx: {}", err);
-                transaction_status.set(Some(TransactionStatus::Error(None)))
+                transaction_status.set(Some(TransactionStatus::Error(GatewayError::Unknown)))
             }
         };
     });

--- a/src/components/submit_transaction/transaction_status.rs
+++ b/src/components/submit_transaction/transaction_status.rs
@@ -7,7 +7,7 @@ use solana_sdk::signature::Signature;
 pub enum TransactionStatus {
     Waiting,
     Denied,
-    Error(Option<GatewayError>),
+    Error(GatewayError),
     Timeout,
     Sending(u8),
     Done(Signature),

--- a/src/components/submit_transaction/transaction_status.rs
+++ b/src/components/submit_transaction/transaction_status.rs
@@ -10,6 +10,7 @@ pub enum TransactionStatus {
     Timeout,
     Sending(u8),
     Done(Signature),
+    InsufficientFunds,
 }
 
 impl Display for TransactionStatus {

--- a/src/components/submit_transaction/transaction_status.rs
+++ b/src/components/submit_transaction/transaction_status.rs
@@ -1,16 +1,16 @@
 use std::fmt::Display;
 
+use crate::gateway::GatewayError;
 use solana_sdk::signature::Signature;
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum TransactionStatus {
     Waiting,
     Denied,
-    Error,
+    Error(Option<GatewayError>),
     Timeout,
     Sending(u8),
     Done(Signature),
-    InsufficientFunds,
 }
 
 impl Display for TransactionStatus {

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -32,7 +32,7 @@ pub enum GatewayError {
     UnableToDeriveKeypair,
     NoWalletsFound,
     InvalidWalletName,
-    InsufficientFunds,
+    InsufficientSOL,
 }
 
 impl From<anyhow::Error> for GatewayError {

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -32,6 +32,7 @@ pub enum GatewayError {
     UnableToDeriveKeypair,
     NoWalletsFound,
     InvalidWalletName,
+    InsufficientFunds,
 }
 
 impl From<anyhow::Error> for GatewayError {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -13,6 +13,7 @@ use serde_json::{json, Value};
 #[cfg(not(feature = "web"))]
 use solana_client::nonblocking::rpc_client::RpcClient;
 
+
 #[cfg(feature = "web")]
 use solana_client_wasm::WasmClient;
 
@@ -20,7 +21,7 @@ use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
     signature::Signature,
-    transaction::{Transaction, VersionedTransaction},
+    transaction::VersionedTransaction,
 };
 
 pub use utils::SimulateTransactionResponse;
@@ -108,18 +109,10 @@ pub trait Rpc {
         &self,
         transaction: &VersionedTransaction,
     ) -> GatewayResult<Signature>;
-
-    #[cfg(not(feature = "web"))]
     async fn simulate_transaction(
         &self,
         transaction: &VersionedTransaction,
-    ) -> GatewayResult<SimulateTransactionResponse>;
-
-    #[cfg(feature = "web")]
-    async fn simulate_transaction(
-        &self,
-        transaction: &Transaction,
-    ) -> GatewayResult<SimulateTransactionResponse>;
+    ) -> GatewayResult<SimulateTransactionResponse>;    
 }
 
 #[cfg(not(feature = "web"))]
@@ -288,7 +281,7 @@ impl Rpc for WebRpc {
     }
     async fn simulate_transaction(
         &self,
-        transaction: &Transaction,
+        transaction: &VersionedTransaction,
     ) -> GatewayResult<SimulateTransactionResponse> {
         match self.0.simulate_transaction(transaction).await {
             Ok(response) => Ok(SimulateTransactionResponse {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -12,11 +12,18 @@ pub use error::*;
 use serde_json::{json, Value};
 #[cfg(not(feature = "web"))]
 use solana_client::nonblocking::rpc_client::RpcClient;
+
 #[cfg(feature = "web")]
 use solana_client_wasm::WasmClient;
+
 use solana_sdk::{
-    hash::Hash, pubkey::Pubkey, signature::Signature, transaction::VersionedTransaction,
+    hash::Hash,
+    pubkey::Pubkey,
+    signature::Signature,
+    transaction::{Transaction, VersionedTransaction},
 };
+
+pub use utils::SimulateTransactionResponse;
 pub use utils::*;
 pub use wss::*;
 
@@ -101,6 +108,18 @@ pub trait Rpc {
         &self,
         transaction: &VersionedTransaction,
     ) -> GatewayResult<Signature>;
+
+    #[cfg(not(feature = "web"))]
+    async fn simulate_transaction(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> GatewayResult<SimulateTransactionResponse>;
+
+    #[cfg(feature = "web")]
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> GatewayResult<SimulateTransactionResponse>;
 }
 
 #[cfg(not(feature = "web"))]
@@ -180,6 +199,23 @@ impl Rpc for NativeRpc {
             .await
             .map_err(From::from)
     }
+
+    async fn simulate_transaction(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> GatewayResult<SimulateTransactionResponse> {
+        match self.0.simulate_transaction(transaction).await {
+            Ok(response) => Ok(SimulateTransactionResponse {
+                err: response.value.err,
+                logs: response.value.logs,
+                units_consumed: response.value.units_consumed,
+            }),
+            Err(err) => {
+                log::error!("Simulation error: {:?}", err);
+                Err(From::from(err))
+            }
+        }
+    }
 }
 
 #[cfg(feature = "web")]
@@ -249,5 +285,21 @@ impl Rpc for WebRpc {
             .send_versioned_transaction(transaction)
             .await
             .map_err(From::from)
+    }
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> GatewayResult<SimulateTransactionResponse> {
+        match self.0.simulate_transaction(transaction).await {
+            Ok(response) => Ok(SimulateTransactionResponse {
+                err: response.err,
+                logs: response.logs,
+                units_consumed: response.units_consumed,
+            }),
+            Err(err) => {
+                log::error!("Simulation error: {:?}", err);
+                Err(From::from(err))
+            }
+        }
     }
 }

--- a/src/hooks/resources/use_boost_apy.rs
+++ b/src/hooks/resources/use_boost_apy.rs
@@ -44,7 +44,7 @@ fn use_boost_yield_resource(address: Pubkey) -> Resource<GatewayResult<BoostYiel
     })
 }
 
-pub fn use_boost_yield(mint_address: Pubkey) -> Resource<GatewayResult<BoostYield>> {
+pub fn _use_boost_yield(mint_address: Pubkey) -> Resource<GatewayResult<BoostYield>> {
     let boost_yields: HashMap<Pubkey, Resource<GatewayResult<BoostYield>>> = use_context();
     let boost_address = boost_pda(mint_address).0;
     if let Some(boost_yield) = boost_yields.get(&boost_address) {

--- a/src/hooks/transaction_builders/use_pool_register_transaction.rs
+++ b/src/hooks/transaction_builders/use_pool_register_transaction.rs
@@ -79,6 +79,9 @@ pub fn use_pool_register_transaction() -> Resource<GatewayResult<VersionedTransa
             // Add jito tip
             ixs.push(tip_ix(&pubkey));
 
+            // Simulate transaction
+            // gateway.rpc.simulate_transaction
+
             // build transaction with priority fee
             let tx_with_priority_fee = Transaction::new_with_payer(&ixs, Some(&pubkey)).into();
             Ok(tx_with_priority_fee)

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -434,7 +434,7 @@ pub fn MinerRewardsClaimButton(
                     ) {
                         transaction_status.set(Some(TransactionStatus::Waiting));
                         let tx_for_signing = tx.clone();
-                        let tx_to_simulate = tx.clone();
+                        let tx_to_simulate = versioned_tx.clone();
 
                         // Simulate transaction
                         let gateway = use_gateway();

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -447,7 +447,7 @@ pub fn MinerRewardsClaimButton(
                                     if let TransactionError::InstructionError(_index, instruction_error) = err {
                                         if matches!(instruction_error, InstructionError::Custom(1)) {
                                             // Handle insufficient funds error
-                                            transaction_status.set(Some(TransactionStatus::Error(GatewayError::InsufficientFunds)));
+                                            transaction_status.set(Some(TransactionStatus::Error(GatewayError::InsufficientSOL)));
                                             return;
                                         }
                                     }

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -466,13 +466,15 @@ pub fn MinerRewardsClaimButton(
                                             );
                                     }
                                     Err(err) => {
-                                        transaction_status.set(Some(TransactionStatus::Error));
+                                        // Clone the error before it's moved into TransactionStatus::Error
+                                        transaction_status.set(Some(TransactionStatus::Error(Some(err.clone()))));
                                         log::error!("{:?}", err);
                                     }
                                 }
                             }
                             Err(err) => {
-                                transaction_status.set(Some(TransactionStatus::Error));
+                                // Clone the error before it's moved into TransactionStatus::Error
+                                transaction_status.set(Some(TransactionStatus::Error(Some(err.clone()))));
                                 log::error!("{:?}", err);
                             }
                         }

--- a/src/pages/mine.rs
+++ b/src/pages/mine.rs
@@ -2,11 +2,11 @@
 use dioxus::prelude::*;
 use ore_api::consts::TOKEN_DECIMALS;
 use ore_miner_types::OutputMessage;
-use solana_sdk::transaction::Transaction;
+use solana_sdk::transaction::{Transaction, VersionedTransaction};
 
 use crate::{
     components::*,
-    gateway::{pool::PoolGateway, GatewayError, GatewayResult},
+    gateway::{pool::PoolGateway, GatewayError, GatewayResult, Rpc},
     hooks::{
         build_commit_claim_instructions, on_transaction_done, use_gateway, use_member,
         use_member_record, use_member_record_balance, use_miner, use_miner_cores,
@@ -340,6 +340,7 @@ fn MinerRewards() -> Element {
     });
     // init claim transaction
     let mut claim_tx = use_signal(|| Err(GatewayError::RequestFailed));
+    let mut versioned_claim_tx = use_signal(|| Err(GatewayError::RequestFailed));
     use_effect(move || {
         if let (Some(Ok(member_db_balance)), Ok(member), Some(pool)) =
             (member_db_balance.cloned(), member.cloned(), pool.cloned())
@@ -351,7 +352,10 @@ fn MinerRewards() -> Element {
                         .await
                 {
                     let tx = Transaction::new_with_payer(&ixs, Some(&member.authority));
-                    claim_tx.set(Ok(tx));
+                    let tx_clone = tx.clone();
+                    claim_tx.set(Ok(tx_clone));
+                    let versioned_tx = VersionedTransaction::from(tx);
+                    versioned_claim_tx.set(Ok(versioned_tx));
                 }
             });
         }
@@ -395,7 +399,7 @@ fn MinerRewards() -> Element {
                     }
                 }
             }
-            MinerRewardsClaimButton { transaction: claim_tx, tx_type: TransactionType::PoolClaim }
+            MinerRewardsClaimButton { transaction: claim_tx, versioned_transaction: versioned_claim_tx, tx_type: TransactionType::PoolClaim }
         }
     }
 }
@@ -403,6 +407,7 @@ fn MinerRewards() -> Element {
 #[component]
 pub fn MinerRewardsClaimButton(
     transaction: Signal<GatewayResult<Transaction>>,
+    versioned_transaction: Signal<GatewayResult<VersionedTransaction>>,
     tx_type: TransactionType,
 ) -> Element {
     let pool_url = use_pool_url();
@@ -421,17 +426,35 @@ pub fn MinerRewardsClaimButton(
             disabled: !enabled,
             onclick: move |_| {
                 spawn(async move {
-                    if let (Some(pool_url), Ok(member), Ok(tx)) = (
+                    if let (Some(pool_url), Ok(member), Ok(tx), Ok(versioned_tx)) = (
                         pool_url.cloned(),
                         member.cloned(),
                         transaction.cloned(),
+                        versioned_transaction.cloned(),
                     ) {
                         transaction_status.set(Some(TransactionStatus::Waiting));
-                        let sign_partial = sign_transaction_partial(tx).await;
+                        let tx_for_signing = tx.clone();
+                        let tx_to_simulate = tx.clone();
+
+                        // Simulate transaction
+                        let gateway = use_gateway();
+                        match gateway.rpc.simulate_transaction(&tx_to_simulate).await {
+                            Ok(response) => {
+                                if let Some(err) = response.err {
+                                    log::error!("Simulation error in mine claim: {:?}", err);
+                                }
+                            },
+                            Err(err) => {
+                                log::error!("Failed to simulate transaction: {:?}", err);
+                            }
+                        };
+
+                        // Sign the transaction
+                        let sign_partial = sign_transaction_partial(tx_for_signing).await;
+
                         match sign_partial {
                             Ok((tx, hash)) => {
                                 transaction_status.set(Some(TransactionStatus::Sending(0)));
-                                let gateway = use_gateway();
                                 match gateway
                                     .commit_claim(member.authority, pool_url, tx, hash)
                                     .await


### PR DESCRIPTION
- Add `simulate_transaction` to our `WebRpc` and `NativeRpc` clients in `mod.rs` for our gateway Rpc traits
- Include `simulate_transaction` in `submit_transaction_web` and `submit_transaction_native`
- Update `Error` enum in `TransactionStatus` to take in `GatewayError` arg
- Add `InsufficientSOL` error to `errors.rs` enum & update `toast.rs` to match + return new error message for InsufficientSOL + GatewayError::Unknown